### PR TITLE
feat: データモデル定義

### DIFF
--- a/src/Mitsuoshie.Core/Models/AlertSeverity.cs
+++ b/src/Mitsuoshie.Core/Models/AlertSeverity.cs
@@ -1,0 +1,8 @@
+namespace Mitsuoshie.Core.Models;
+
+public enum AlertSeverity
+{
+    Info,
+    Warning,
+    Critical
+}

--- a/src/Mitsuoshie.Core/Models/DeployedToken.cs
+++ b/src/Mitsuoshie.Core/Models/DeployedToken.cs
@@ -1,0 +1,8 @@
+namespace Mitsuoshie.Core.Models;
+
+public record DeployedToken(
+    string FilePath,
+    HoneyTokenType HoneyType,
+    string OriginalHash,
+    DateTime DeployedAt
+);

--- a/src/Mitsuoshie.Core/Models/HoneyTokenType.cs
+++ b/src/Mitsuoshie.Core/Models/HoneyTokenType.cs
@@ -1,0 +1,12 @@
+namespace Mitsuoshie.Core.Models;
+
+public enum HoneyTokenType
+{
+    AwsCredential,
+    SshKey,
+    EnvFile,
+    PasswordFile,
+    CryptoWallet,
+    BrowserLoginData,
+    ConfidentialDocument
+}

--- a/src/Mitsuoshie.Core/Models/MitsuoshieAlert.cs
+++ b/src/Mitsuoshie.Core/Models/MitsuoshieAlert.cs
@@ -1,0 +1,18 @@
+namespace Mitsuoshie.Core.Models;
+
+public record MitsuoshieAlert
+{
+    public required DateTime Timestamp { get; init; }
+    public required string HoneyFile { get; init; }
+    public required HoneyTokenType HoneyType { get; init; }
+    public required string EventType { get; init; }
+    public required bool Tampered { get; init; }
+    public required string OriginalHash { get; init; }
+    public required string CurrentHash { get; init; }
+    public required string AccessMask { get; init; }
+    public required int ProcessId { get; init; }
+    public required string ProcessName { get; init; }
+    public required string ProcessPath { get; init; }
+    public required string User { get; init; }
+    public required AlertSeverity Severity { get; init; }
+}

--- a/tests/Mitsuoshie.Core.Tests/Models/DeployedTokenTests.cs
+++ b/tests/Mitsuoshie.Core.Tests/Models/DeployedTokenTests.cs
@@ -1,0 +1,33 @@
+namespace Mitsuoshie.Core.Tests.Models;
+
+using Mitsuoshie.Core.Models;
+
+public class DeployedTokenTests
+{
+    [Fact]
+    public void DeployedToken_CanBeCreated()
+    {
+        var now = DateTime.UtcNow;
+        var token = new DeployedToken(
+            FilePath: @"C:\Users\test\.aws\credentials.bak",
+            HoneyType: HoneyTokenType.AwsCredential,
+            OriginalHash: "abc123",
+            DeployedAt: now
+        );
+
+        Assert.Equal(@"C:\Users\test\.aws\credentials.bak", token.FilePath);
+        Assert.Equal(HoneyTokenType.AwsCredential, token.HoneyType);
+        Assert.Equal("abc123", token.OriginalHash);
+        Assert.Equal(now, token.DeployedAt);
+    }
+
+    [Fact]
+    public void DeployedToken_IsImmutable_Record()
+    {
+        var token = new DeployedToken("path", HoneyTokenType.SshKey, "hash", DateTime.UtcNow);
+        var copy = token with { FilePath = "new_path" };
+
+        Assert.NotEqual(token.FilePath, copy.FilePath);
+        Assert.Equal(token.HoneyType, copy.HoneyType);
+    }
+}

--- a/tests/Mitsuoshie.Core.Tests/Models/HoneyTokenTypeTests.cs
+++ b/tests/Mitsuoshie.Core.Tests/Models/HoneyTokenTypeTests.cs
@@ -1,0 +1,18 @@
+namespace Mitsuoshie.Core.Tests.Models;
+
+using Mitsuoshie.Core.Models;
+
+public class HoneyTokenTypeTests
+{
+    [Fact]
+    public void HoneyTokenType_HasExpectedValues()
+    {
+        Assert.True(Enum.IsDefined(typeof(HoneyTokenType), HoneyTokenType.AwsCredential));
+        Assert.True(Enum.IsDefined(typeof(HoneyTokenType), HoneyTokenType.SshKey));
+        Assert.True(Enum.IsDefined(typeof(HoneyTokenType), HoneyTokenType.EnvFile));
+        Assert.True(Enum.IsDefined(typeof(HoneyTokenType), HoneyTokenType.PasswordFile));
+        Assert.True(Enum.IsDefined(typeof(HoneyTokenType), HoneyTokenType.CryptoWallet));
+        Assert.True(Enum.IsDefined(typeof(HoneyTokenType), HoneyTokenType.BrowserLoginData));
+        Assert.True(Enum.IsDefined(typeof(HoneyTokenType), HoneyTokenType.ConfidentialDocument));
+    }
+}

--- a/tests/Mitsuoshie.Core.Tests/Models/MitsuoshieAlertTests.cs
+++ b/tests/Mitsuoshie.Core.Tests/Models/MitsuoshieAlertTests.cs
@@ -1,0 +1,55 @@
+namespace Mitsuoshie.Core.Tests.Models;
+
+using Mitsuoshie.Core.Models;
+
+public class MitsuoshieAlertTests
+{
+    [Fact]
+    public void MitsuoshieAlert_CanBeCreated()
+    {
+        var alert = new MitsuoshieAlert
+        {
+            Timestamp = DateTime.UtcNow,
+            HoneyFile = @"C:\Users\test\.aws\credentials.bak",
+            HoneyType = HoneyTokenType.AwsCredential,
+            EventType = "ReadData",
+            Tampered = false,
+            OriginalHash = "abc",
+            CurrentHash = "abc",
+            AccessMask = "0x1",
+            ProcessId = 1234,
+            ProcessName = "malware.exe",
+            ProcessPath = @"C:\temp\malware.exe",
+            User = @"DESKTOP\user",
+            Severity = AlertSeverity.Critical
+        };
+
+        Assert.Equal("ReadData", alert.EventType);
+        Assert.False(alert.Tampered);
+        Assert.Equal(AlertSeverity.Critical, alert.Severity);
+    }
+
+    [Fact]
+    public void MitsuoshieAlert_Tampered_WhenHashesDiffer()
+    {
+        var alert = new MitsuoshieAlert
+        {
+            Timestamp = DateTime.UtcNow,
+            HoneyFile = "file",
+            HoneyType = HoneyTokenType.SshKey,
+            EventType = "Tampered",
+            Tampered = true,
+            OriginalHash = "original",
+            CurrentHash = "modified",
+            AccessMask = "0x2",
+            ProcessId = 5678,
+            ProcessName = "evil.exe",
+            ProcessPath = @"C:\evil.exe",
+            User = "user",
+            Severity = AlertSeverity.Critical
+        };
+
+        Assert.True(alert.Tampered);
+        Assert.NotEqual(alert.OriginalHash, alert.CurrentHash);
+    }
+}


### PR DESCRIPTION
## Summary
- `HoneyTokenType` enum — 罠ファイル7種別（AWS, SSH, env, password, wallet, browser, document）
- `DeployedToken` record — 配置済みトークン情報（パス、種別、ハッシュ、日時）
- `MitsuoshieAlert` record — アラート情報（プロセス、アクセス、改ざん検知）
- `AlertSeverity` enum — Info / Warning / Critical

Closes #2

## Test plan
- [x] `HoneyTokenType` の全値が定義されている
- [x] `DeployedToken` の生成・イミュータブル性
- [x] `MitsuoshieAlert` の生成・改ざん検知フィールド
- [x] `dotnet test` 全6件 Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)