### PR TITLE
feat: HoneyDeployer 実装（罠ファイル配置ロジック）

### DIFF
--- a/src/Mitsuoshie.Core/Deployment/HoneyDeployer.cs
+++ b/src/Mitsuoshie.Core/Deployment/HoneyDeployer.cs
@@ -1,0 +1,97 @@
+using System.Security.Cryptography;
+using System.Text;
+using Mitsuoshie.Core.Models;
+
+namespace Mitsuoshie.Core.Deployment;
+
+public class HoneyDeployer
+{
+    private readonly string _userProfileDir;
+
+    // 隠しフォルダ属性を付与するディレクトリ名
+    private static readonly HashSet<string> HiddenFolderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".secure",
+        ".confidential"
+    };
+
+    public HoneyDeployer(string userProfileDir)
+    {
+        _userProfileDir = userProfileDir ?? throw new ArgumentNullException(nameof(userProfileDir));
+    }
+
+    public DeployedToken? DeploySingle(HoneyTokenType type)
+    {
+        var relativePath = HoneyTemplates.GetRelativePath(type);
+        var fullPath = Path.Combine(_userProfileDir, relativePath);
+
+        // 既存ファイルは絶対に上書きしない
+        if (File.Exists(fullPath))
+        {
+            return null;
+        }
+
+        // ディレクトリ作成
+        var dirPath = Path.GetDirectoryName(fullPath)!;
+        Directory.CreateDirectory(dirPath);
+
+        // 隠しフォルダ属性の付与
+        SetHiddenAttributeIfNeeded(dirPath);
+
+        // コンテンツ生成・書き込み
+        var content = HoneyTemplates.GenerateContent(type);
+        File.WriteAllText(fullPath, content, Encoding.UTF8);
+
+        // ファイルの更新日時を過去に設定（3〜12ヶ月前のランダムな日時）
+        var daysAgo = RandomNumberGenerator.GetInt32(90, 365);
+        var pastDate = DateTime.UtcNow.AddDays(-daysAgo);
+        File.SetLastWriteTimeUtc(fullPath, pastDate);
+        File.SetCreationTimeUtc(fullPath, pastDate.AddDays(-RandomNumberGenerator.GetInt32(1, 30)));
+
+        // SHA256 ハッシュ計算
+        var hash = ComputeSHA256(fullPath);
+
+        return new DeployedToken(
+            FilePath: fullPath,
+            HoneyType: type,
+            OriginalHash: hash,
+            DeployedAt: DateTime.UtcNow
+        );
+    }
+
+    public List<DeployedToken> DeployAll()
+    {
+        var results = new List<DeployedToken>();
+
+        foreach (var type in Enum.GetValues<HoneyTokenType>())
+        {
+            var result = DeploySingle(type);
+            if (result is not null)
+            {
+                results.Add(result);
+            }
+        }
+
+        return results;
+    }
+
+    private void SetHiddenAttributeIfNeeded(string dirPath)
+    {
+        // ディレクトリ階層を走査して、隠しフォルダ対象を探す
+        var dir = new DirectoryInfo(dirPath);
+        while (dir is not null && dir.FullName != _userProfileDir)
+        {
+            if (HiddenFolderNames.Contains(dir.Name))
+            {
+                dir.Attributes |= FileAttributes.Hidden;
+            }
+            dir = dir.Parent;
+        }
+    }
+
+    private static string ComputeSHA256(string filePath)
+    {
+        var fileBytes = File.ReadAllBytes(filePath);
+        return Convert.ToHexStringLower(SHA256.HashData(fileBytes));
+    }
+}

--- a/tests/Mitsuoshie.Core.Tests/Deployment/HoneyDeployerTests.cs
+++ b/tests/Mitsuoshie.Core.Tests/Deployment/HoneyDeployerTests.cs
@@ -1,0 +1,139 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Mitsuoshie.Core.Tests.Deployment;
+
+using Mitsuoshie.Core.Deployment;
+using Mitsuoshie.Core.Models;
+
+public class HoneyDeployerTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly HoneyDeployer _deployer;
+
+    public HoneyDeployerTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), "mitsuoshie_test_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_testDir);
+        _deployer = new HoneyDeployer(_testDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+        {
+            Directory.Delete(_testDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DeploySingle_CreatesFileAtExpectedPath()
+    {
+        var result = _deployer.DeploySingle(HoneyTokenType.AwsCredential);
+
+        Assert.NotNull(result);
+        var expectedPath = Path.Combine(_testDir, @".aws\credentials.bak");
+        Assert.Equal(expectedPath, result.FilePath);
+        Assert.True(File.Exists(result.FilePath));
+    }
+
+    [Fact]
+    public void DeploySingle_CreatesDirectoryIfNotExists()
+    {
+        _deployer.DeploySingle(HoneyTokenType.AwsCredential);
+
+        var awsDir = Path.Combine(_testDir, ".aws");
+        Assert.True(Directory.Exists(awsDir));
+    }
+
+    [Fact]
+    public void DeploySingle_DoesNotOverwriteExistingFile()
+    {
+        var filePath = Path.Combine(_testDir, @".aws\credentials.bak");
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+        File.WriteAllText(filePath, "existing content");
+
+        var result = _deployer.DeploySingle(HoneyTokenType.AwsCredential);
+
+        Assert.Null(result); // スキップされる
+        Assert.Equal("existing content", File.ReadAllText(filePath));
+    }
+
+    [Fact]
+    public void DeploySingle_RecordsSHA256Hash()
+    {
+        var result = _deployer.DeploySingle(HoneyTokenType.AwsCredential);
+
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.OriginalHash);
+
+        // ハッシュを検証
+        var fileBytes = File.ReadAllBytes(result.FilePath);
+        var expectedHash = Convert.ToHexStringLower(SHA256.HashData(fileBytes));
+        Assert.Equal(expectedHash, result.OriginalHash);
+    }
+
+    [Fact]
+    public void DeploySingle_SetsCorrectHoneyType()
+    {
+        var result = _deployer.DeploySingle(HoneyTokenType.SshKey);
+
+        Assert.NotNull(result);
+        Assert.Equal(HoneyTokenType.SshKey, result.HoneyType);
+    }
+
+    [Fact]
+    public void DeploySingle_SetsFileTimestampInPast()
+    {
+        var result = _deployer.DeploySingle(HoneyTokenType.AwsCredential);
+
+        Assert.NotNull(result);
+        var lastWrite = File.GetLastWriteTimeUtc(result.FilePath);
+        Assert.True(lastWrite < DateTime.UtcNow.AddDays(-30),
+            "File timestamp should be set to a past date");
+    }
+
+    [Fact]
+    public void DeployAll_DeploysAllTokenTypes()
+    {
+        var results = _deployer.DeployAll();
+
+        var tokenTypes = Enum.GetValues<HoneyTokenType>();
+        Assert.Equal(tokenTypes.Length, results.Count);
+
+        foreach (var type in tokenTypes)
+        {
+            Assert.Contains(results, r => r.HoneyType == type);
+        }
+    }
+
+    [Fact]
+    public void DeployAll_SkipsExistingFiles()
+    {
+        // 1つだけ既存ファイルを配置
+        var awsPath = Path.Combine(_testDir, @".aws\credentials.bak");
+        Directory.CreateDirectory(Path.GetDirectoryName(awsPath)!);
+        File.WriteAllText(awsPath, "existing");
+
+        var results = _deployer.DeployAll();
+
+        // AWS 以外は配置される
+        var tokenTypes = Enum.GetValues<HoneyTokenType>();
+        Assert.Equal(tokenTypes.Length - 1, results.Count);
+        Assert.DoesNotContain(results, r => r.HoneyType == HoneyTokenType.AwsCredential);
+    }
+
+    [Fact]
+    public void DeploySingle_HiddenFolders_AreHidden()
+    {
+        // Documents\.secure\ と Desktop\.confidential\ は隠しフォルダ
+        _deployer.DeploySingle(HoneyTokenType.PasswordFile);
+
+        var secureDir = Path.Combine(_testDir, @"Documents\.secure");
+        Assert.True(Directory.Exists(secureDir));
+
+        var attrs = File.GetAttributes(secureDir);
+        Assert.True((attrs & FileAttributes.Hidden) != 0,
+            ".secure folder should have Hidden attribute");
+    }
+}


### PR DESCRIPTION
## Summary
- `HoneyDeployer` — 罠ファイルをファイルシステムに配置するコアロジック
- 既存ファイルは絶対に上書きしない（`null` を返してスキップ）
- `.secure` / `.confidential` フォルダに隠し属性を自動付与
- ファイルタイムスタンプを3〜12ヶ月前にランダム設定（自然に見せる）
- SHA256 ハッシュを計算・記録

Closes #4

## Test plan
- [x] ファイルが期待パスに配置される
- [x] ディレクトリが自動作成される
- [x] 既存ファイルが上書きされない
- [x] SHA256ハッシュが正しく記録される
- [x] ファイルタイムスタンプが過去に設定される
- [x] 隠しフォルダ属性が付与される
- [x] DeployAll で全7種別が配置される
- [x] DeployAll で既存ファイルがスキップされる
- [x] `dotnet test` 全30件 Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)