### PR TITLE
feat: SaclConfigurator 実装（NTFS 監査 ACL 設定）

### DIFF
--- a/src/Mitsuoshie.Core/Deployment/SaclConfigurator.cs
+++ b/src/Mitsuoshie.Core/Deployment/SaclConfigurator.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace Mitsuoshie.Core.Deployment;
+
+[SupportedOSPlatform("windows")]
+public static class SaclConfigurator
+{
+    /// <summary>
+    /// 罠ファイルに NTFS 監査 ACL を設定する。
+    /// Everyone に対する ReadData, WriteData, Delete, AppendData を監査対象にする。
+    /// </summary>
+    public static void SetAuditRule(string filePath)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        ArgumentException.ThrowIfNullOrEmpty(filePath);
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException("罠ファイルが見つかりません。", filePath);
+
+        var fileInfo = new FileInfo(filePath);
+        var security = fileInfo.GetAccessControl(AccessControlSections.Audit);
+
+        var auditRule = new FileSystemAuditRule(
+            identity: new SecurityIdentifier(WellKnownSidType.WorldSid, null),
+            fileSystemRights: FileSystemRights.ReadData
+                            | FileSystemRights.WriteData
+                            | FileSystemRights.Delete
+                            | FileSystemRights.AppendData,
+            flags: AuditFlags.Success
+        );
+
+        security.AddAuditRule(auditRule);
+        fileInfo.SetAccessControl(security);
+    }
+
+    /// <summary>
+    /// ファイルシステム監査ポリシーを有効化する（管理者権限が必要）。
+    /// auditpol /set /subcategory:"File System" /success:enable を実行。
+    /// </summary>
+    public static void EnableFileSystemAuditing()
+    {
+        if (!IsAdministrator())
+            throw new InvalidOperationException(
+                "ファイルシステム監査の有効化には管理者権限が必要です。");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "auditpol",
+            Arguments = "/set /subcategory:\"File System\" /success:enable",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi);
+        process?.WaitForExit(TimeSpan.FromSeconds(30));
+
+        if (process?.ExitCode != 0)
+        {
+            var error = process?.StandardError.ReadToEnd();
+            throw new InvalidOperationException(
+                $"監査ポリシーの有効化に失敗しました: {error}");
+        }
+    }
+
+    /// <summary>
+    /// 現在のプロセスが管理者権限で実行されているかを確認する。
+    /// </summary>
+    public static bool IsAdministrator()
+    {
+        using var identity = WindowsIdentity.GetCurrent();
+        var principal = new WindowsPrincipal(identity);
+        return principal.IsInRole(WindowsBuiltInRole.Administrator);
+    }
+}

--- a/src/Mitsuoshie.Core/Mitsuoshie.Core.csproj
+++ b/src/Mitsuoshie.Core/Mitsuoshie.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/Mitsuoshie.Core.Tests/Deployment/SaclConfiguratorTests.cs
+++ b/tests/Mitsuoshie.Core.Tests/Deployment/SaclConfiguratorTests.cs
@@ -1,0 +1,62 @@
+namespace Mitsuoshie.Core.Tests.Deployment;
+
+using Mitsuoshie.Core.Deployment;
+
+public class SaclConfiguratorTests : IDisposable
+{
+    private readonly string _testDir;
+
+    public SaclConfiguratorTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), "mitsuoshie_sacl_test_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_testDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+            Directory.Delete(_testDir, recursive: true);
+    }
+
+    [Fact]
+    public void IsAdministrator_ReturnsBool()
+    {
+        // 実行環境によって true/false は変わるが、例外は出ない
+        var result = SaclConfigurator.IsAdministrator();
+        Assert.IsType<bool>(result);
+    }
+
+    [Fact]
+    public void SetAuditRule_ThrowsFileNotFoundException_ForMissingFile()
+    {
+        var missingFile = Path.Combine(_testDir, "nonexistent.txt");
+
+        Assert.Throws<FileNotFoundException>(() =>
+            SaclConfigurator.SetAuditRule(missingFile));
+    }
+
+    [Fact]
+    public void SetAuditRule_ThrowsArgumentNullException_ForNullPath()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            SaclConfigurator.SetAuditRule(null!));
+    }
+
+    [Fact]
+    public void SetAuditRule_ThrowsArgumentException_ForEmptyPath()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            SaclConfigurator.SetAuditRule(""));
+    }
+
+    [Fact]
+    public void EnableFileSystemAuditing_DoesNotThrow_WhenNotAdmin()
+    {
+        // 管理者でない場合は InvalidOperationException
+        if (!SaclConfigurator.IsAdministrator())
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                SaclConfigurator.EnableFileSystemAuditing());
+        }
+    }
+}

--- a/tests/Mitsuoshie.Core.Tests/Mitsuoshie.Core.Tests.csproj
+++ b/tests/Mitsuoshie.Core.Tests/Mitsuoshie.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary
- `SaclConfigurator.SetAuditRule()` — 罠ファイルに NTFS 監査 ACL を設定
- `SaclConfigurator.EnableFileSystemAuditing()` — auditpol で監査ポリシー有効化
- `SaclConfigurator.IsAdministrator()` — 管理者権限チェック
- TargetFramework を `net10.0-windows` に変更（System.Security.AccessControl 使用）

Closes #5

## Test plan
- [x] `IsAdministrator` が例外なく bool を返す
- [x] 存在しないファイルに SetAuditRule → FileNotFoundException
- [x] null/空パスに SetAuditRule → ArgumentNullException/ArgumentException
- [x] 非管理者で EnableFileSystemAuditing → InvalidOperationException
- [x] `dotnet test` 全35件 Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)