### PR TITLE
feat: 配置結果の JSON 設定ファイル記録

### DIFF
--- a/src/Mitsuoshie.Core/Models/SettingsStore.cs
+++ b/src/Mitsuoshie.Core/Models/SettingsStore.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Mitsuoshie.Core.Models;
+
+public class SettingsStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private readonly string _filePath;
+    private readonly Dictionary<string, DeployedToken> _tokensByPath = new(StringComparer.OrdinalIgnoreCase);
+
+    public IReadOnlyList<DeployedToken> Tokens => _tokensByPath.Values.ToList();
+
+    public SettingsStore(string filePath)
+    {
+        _filePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+    }
+
+    public void AddToken(DeployedToken token)
+    {
+        _tokensByPath[token.FilePath] = token;
+    }
+
+    public string? GetOriginalHash(string filePath)
+    {
+        return _tokensByPath.TryGetValue(filePath, out var token) ? token.OriginalHash : null;
+    }
+
+    public HoneyTokenType? GetHoneyType(string filePath)
+    {
+        return _tokensByPath.TryGetValue(filePath, out var token) ? token.HoneyType : null;
+    }
+
+    public bool ContainsPath(string filePath)
+    {
+        return _tokensByPath.ContainsKey(filePath);
+    }
+
+    public void Save()
+    {
+        var dir = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        var data = new SettingsData
+        {
+            DeployedTokens = _tokensByPath.Values.ToList()
+        };
+
+        var json = JsonSerializer.Serialize(data, JsonOptions);
+        File.WriteAllText(_filePath, json);
+    }
+
+    public static SettingsStore Load(string filePath)
+    {
+        var store = new SettingsStore(filePath);
+
+        if (!File.Exists(filePath))
+            return store;
+
+        var json = File.ReadAllText(filePath);
+        var data = JsonSerializer.Deserialize<SettingsData>(json, JsonOptions);
+
+        if (data?.DeployedTokens is not null)
+        {
+            foreach (var token in data.DeployedTokens)
+            {
+                store.AddToken(token);
+            }
+        }
+
+        return store;
+    }
+
+    private record SettingsData
+    {
+        public List<DeployedToken> DeployedTokens { get; init; } = [];
+    }
+}

--- a/tests/Mitsuoshie.Core.Tests/Models/SettingsStoreTests.cs
+++ b/tests/Mitsuoshie.Core.Tests/Models/SettingsStoreTests.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+
+namespace Mitsuoshie.Core.Tests.Models;
+
+using Mitsuoshie.Core.Models;
+
+public class SettingsStoreTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly string _settingsPath;
+
+    public SettingsStoreTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), "mitsuoshie_settings_test_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_testDir);
+        _settingsPath = Path.Combine(_testDir, "settings.json");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+            Directory.Delete(_testDir, recursive: true);
+    }
+
+    [Fact]
+    public void Save_CreatesJsonFile()
+    {
+        var store = new SettingsStore(_settingsPath);
+        var token = new DeployedToken("path", HoneyTokenType.AwsCredential, "hash", DateTime.UtcNow);
+
+        store.AddToken(token);
+        store.Save();
+
+        Assert.True(File.Exists(_settingsPath));
+    }
+
+    [Fact]
+    public void Save_And_Load_PreservesTokens()
+    {
+        var now = DateTime.UtcNow;
+        var store = new SettingsStore(_settingsPath);
+        store.AddToken(new DeployedToken(@"C:\test\.aws\credentials.bak", HoneyTokenType.AwsCredential, "hash1", now));
+        store.AddToken(new DeployedToken(@"C:\test\.ssh\id_rsa.old", HoneyTokenType.SshKey, "hash2", now));
+        store.Save();
+
+        var loaded = SettingsStore.Load(_settingsPath);
+
+        Assert.Equal(2, loaded.Tokens.Count);
+        Assert.Contains(loaded.Tokens, t => t.HoneyType == HoneyTokenType.AwsCredential);
+        Assert.Contains(loaded.Tokens, t => t.HoneyType == HoneyTokenType.SshKey);
+    }
+
+    [Fact]
+    public void Load_ReturnsEmpty_WhenFileDoesNotExist()
+    {
+        var loaded = SettingsStore.Load(Path.Combine(_testDir, "nonexistent.json"));
+
+        Assert.Empty(loaded.Tokens);
+    }
+
+    [Fact]
+    public void GetOriginalHash_ReturnsHash_ForKnownPath()
+    {
+        var store = new SettingsStore(_settingsPath);
+        store.AddToken(new DeployedToken("path1", HoneyTokenType.AwsCredential, "abc123", DateTime.UtcNow));
+
+        Assert.Equal("abc123", store.GetOriginalHash("path1"));
+    }
+
+    [Fact]
+    public void GetOriginalHash_ReturnsNull_ForUnknownPath()
+    {
+        var store = new SettingsStore(_settingsPath);
+
+        Assert.Null(store.GetOriginalHash("unknown"));
+    }
+
+    [Fact]
+    public void GetHoneyType_ReturnsType_ForKnownPath()
+    {
+        var store = new SettingsStore(_settingsPath);
+        store.AddToken(new DeployedToken("path1", HoneyTokenType.SshKey, "hash", DateTime.UtcNow));
+
+        Assert.Equal(HoneyTokenType.SshKey, store.GetHoneyType("path1"));
+    }
+
+    [Fact]
+    public void ContainsPath_ReturnsTrue_ForKnownPath()
+    {
+        var store = new SettingsStore(_settingsPath);
+        store.AddToken(new DeployedToken("path1", HoneyTokenType.EnvFile, "hash", DateTime.UtcNow));
+
+        Assert.True(store.ContainsPath("path1"));
+        Assert.False(store.ContainsPath("unknown"));
+    }
+
+    [Fact]
+    public void Save_ProducesValidJson()
+    {
+        var store = new SettingsStore(_settingsPath);
+        store.AddToken(new DeployedToken("path", HoneyTokenType.AwsCredential, "hash", DateTime.UtcNow));
+        store.Save();
+
+        var json = File.ReadAllText(_settingsPath);
+        var doc = JsonDocument.Parse(json); // パースできれば有効なJSON
+        Assert.NotNull(doc);
+    }
+}


### PR DESCRIPTION
## Summary
- `SettingsStore` — 配置済みトークンの JSON 永続化
- パスベースの高速ルックアップ（`GetOriginalHash`, `GetHoneyType`, `ContainsPath`）
- ファイル未存在時はグレースフルに空ストアを返却
- `JsonStringEnumConverter` で enum を文字列保存（可読性向上）

Closes #6

## Test plan
- [x] Save でJSONファイルが作成される
- [x] Save → Load でトークンが復元される
- [x] 未存在ファイルの Load で空ストアが返る
- [x] GetOriginalHash / GetHoneyType / ContainsPath が正しく動作
- [x] 出力が有効なJSON
- [x] `dotnet test` 全43件 Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)