### PR TITLE
feat: SafeProcessFilter 実装（安全プロセス除外）

### DIFF
--- a/src/Mitsuoshie.Core/Monitoring/SafeProcessFilter.cs
+++ b/src/Mitsuoshie.Core/Monitoring/SafeProcessFilter.cs
@@ -1,0 +1,42 @@
+namespace Mitsuoshie.Core.Monitoring;
+
+public class SafeProcessFilter
+{
+    private const string ReadAttributesMask = "0x80";
+
+    private readonly HashSet<string> _safeProcessNames;
+    private readonly int _currentProcessId;
+
+    public SafeProcessFilter(IEnumerable<string> safeProcessNames, int currentProcessId)
+    {
+        _safeProcessNames = new HashSet<string>(
+            safeProcessNames,
+            StringComparer.OrdinalIgnoreCase
+        );
+        _currentProcessId = currentProcessId;
+    }
+
+    /// <summary>
+    /// プロセスが安全（アラート不要）かどうかを判定する。
+    /// </summary>
+    public bool IsSafe(string processPath, string accessMask, int processId)
+    {
+        // Mitsuoshie 自身のアクセスは除外
+        if (processId == _currentProcessId)
+            return true;
+
+        // ReadAttributes (0x80) のみのアクセスは常に除外（フォルダ表示等）
+        if (accessMask == ReadAttributesMask)
+            return true;
+
+        var processName = Path.GetFileName(processPath);
+
+        // 常時除外リストに含まれるプロセス
+        if (_safeProcessNames.Contains(processName))
+            return true;
+
+        // explorer.exe は ReadAttributes のみ除外（上で処理済み）
+        // それ以外のアクセスマスクならアラート対象
+        return false;
+    }
+}

--- a/tests/Mitsuoshie.Core.Tests/Monitoring/SafeProcessFilterTests.cs
+++ b/tests/Mitsuoshie.Core.Tests/Monitoring/SafeProcessFilterTests.cs
@@ -1,0 +1,78 @@
+namespace Mitsuoshie.Core.Tests.Monitoring;
+
+using Mitsuoshie.Core.Monitoring;
+
+public class SafeProcessFilterTests
+{
+    private readonly SafeProcessFilter _filter;
+
+    public SafeProcessFilterTests()
+    {
+        _filter = new SafeProcessFilter(
+            safeProcessNames: ["MsMpEng.exe", "SearchIndexer.exe", "SearchProtocolHost.exe", "TiWorker.exe", "consent.exe"],
+            currentProcessId: 9999
+        );
+    }
+
+    [Theory]
+    [InlineData("MsMpEng.exe", "0x1", true)]       // Windows Defender — 常時除外
+    [InlineData("MsMpEng.exe", "0x80", true)]
+    [InlineData("SearchIndexer.exe", "0x1", true)]  // Search Indexer — 常時除外
+    [InlineData("TiWorker.exe", "0x1", true)]       // Windows Update — 常時除外
+    [InlineData("consent.exe", "0x1", true)]        // UAC — 常時除外
+    public void IsSafe_AlwaysExcludedProcesses_ReturnsTrue(string processName, string accessMask, bool expected)
+    {
+        Assert.Equal(expected, _filter.IsSafe(processName, accessMask, processId: 1234));
+    }
+
+    [Theory]
+    [InlineData("explorer.exe", "0x80", true)]     // ReadAttributes のみ — 除外（フォルダ表示）
+    [InlineData("explorer.exe", "0x1", false)]     // ReadData — アラート対象
+    [InlineData("explorer.exe", "0x2", false)]     // WriteData — アラート対象
+    [InlineData("explorer.exe", "0x10000", false)] // DELETE — アラート対象
+    public void IsSafe_Explorer_DependsOnAccessMask(string processName, string accessMask, bool expected)
+    {
+        Assert.Equal(expected, _filter.IsSafe(processName, accessMask, processId: 1234));
+    }
+
+    [Fact]
+    public void IsSafe_CurrentProcess_ReturnsTrue()
+    {
+        // Mitsuoshie 自身のプロセスは除外
+        Assert.True(_filter.IsSafe("anything.exe", "0x1", processId: 9999));
+    }
+
+    [Theory]
+    [InlineData("malware.exe", "0x1", false)]
+    [InlineData("stealer.exe", "0x2", false)]
+    [InlineData("unknown.exe", "0x10000", false)]
+    [InlineData("powershell.exe", "0x1", false)]
+    [InlineData("cmd.exe", "0x1", false)]
+    public void IsSafe_UnknownProcesses_ReturnsFalse(string processName, string accessMask, bool expected)
+    {
+        Assert.Equal(expected, _filter.IsSafe(processName, accessMask, processId: 1234));
+    }
+
+    [Fact]
+    public void IsSafe_CaseInsensitive()
+    {
+        Assert.True(_filter.IsSafe("MSMPENG.EXE", "0x1", processId: 1234));
+        Assert.True(_filter.IsSafe("msmpeng.exe", "0x1", processId: 1234));
+        Assert.True(_filter.IsSafe("Explorer.exe", "0x80", processId: 1234));
+    }
+
+    [Fact]
+    public void IsSafe_FullPath_ExtractsFileName()
+    {
+        Assert.True(_filter.IsSafe(@"C:\Windows\System32\MsMpEng.exe", "0x1", processId: 1234));
+        Assert.True(_filter.IsSafe(@"C:\Windows\explorer.exe", "0x80", processId: 1234));
+        Assert.False(_filter.IsSafe(@"C:\temp\malware.exe", "0x1", processId: 1234));
+    }
+
+    [Fact]
+    public void IsSafe_ReadAttributesOnly_AlwaysExcluded()
+    {
+        // ReadAttributes (0x80) のみのアクセスはどのプロセスでも除外
+        Assert.True(_filter.IsSafe("unknown.exe", "0x80", processId: 1234));
+    }
+}


### PR DESCRIPTION
## Summary
- `SafeProcessFilter` — Security Event のプロセスフィルタリング
- 常時除外リスト（Defender, Search, Windows Update 等）
- ReadAttributes のみは全プロセスで除外（フォルダ表示）
- explorer.exe の ReadData はアラート対象（攻撃者がエクスプローラー経由で読む場合も検知）
- 自プロセスID 除外

Closes #13

## Test plan
- [x] 常時除外プロセスが正しく除外される（5件）
- [x] explorer.exe のアクセスマスク別判定（4件）
- [x] 自プロセス除外
- [x] 未知プロセスがアラート対象（5件）
- [x] 大文字小文字の区別なし
- [x] フルパスからファイル名抽出
- [x] ReadAttributes のみは常に除外
- [x] `dotnet test` 全61件 Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)