### PR TITLE
feat: SecurityEventSubscriber 実装（Event ID 4663 購読）

### DIFF
--- a/src/Mitsuoshie.Core/Monitoring/SecurityEventData.cs
+++ b/src/Mitsuoshie.Core/Monitoring/SecurityEventData.cs
@@ -1,0 +1,26 @@
+namespace Mitsuoshie.Core.Monitoring;
+
+/// <summary>
+/// Security Event Log の Event ID 4663 から抽出したデータ。
+/// EventLogWatcher からの生イベントをこの形式に変換して処理する。
+/// </summary>
+public record SecurityEventData
+{
+    /// <summary>アクセスされたオブジェクトのパス（Object Name）</summary>
+    public required string ObjectName { get; init; }
+
+    /// <summary>アクセスマスク（0x1=ReadData, 0x2=WriteData, 0x10000=Delete 等）</summary>
+    public required string AccessMask { get; init; }
+
+    /// <summary>アクセスしたプロセスのID</summary>
+    public required int ProcessId { get; init; }
+
+    /// <summary>アクセスしたプロセスのフルパス</summary>
+    public required string ProcessName { get; init; }
+
+    /// <summary>ユーザー名</summary>
+    public required string UserName { get; init; }
+
+    /// <summary>イベント発生日時（省略時は現在時刻）</summary>
+    public DateTime? Timestamp { get; init; }
+}

--- a/src/Mitsuoshie.Core/Monitoring/SecurityEventSubscriber.cs
+++ b/src/Mitsuoshie.Core/Monitoring/SecurityEventSubscriber.cs
@@ -1,0 +1,82 @@
+using System.Security.Cryptography;
+using Mitsuoshie.Core.Models;
+
+namespace Mitsuoshie.Core.Monitoring;
+
+public class SecurityEventSubscriber
+{
+    private readonly SettingsStore _store;
+    private readonly SafeProcessFilter _filter;
+
+    public event Action<MitsuoshieAlert>? AlertRaised;
+
+    public SecurityEventSubscriber(SettingsStore store, SafeProcessFilter filter)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _filter = filter ?? throw new ArgumentNullException(nameof(filter));
+    }
+
+    /// <summary>
+    /// Security Event を処理し、罠ファイルへのアクセスであればアラートを生成する。
+    /// </summary>
+    public void ProcessEvent(SecurityEventData evt)
+    {
+        // 罠ファイルでなければ無視
+        if (!_store.ContainsPath(evt.ObjectName))
+            return;
+
+        // 安全プロセスは除外
+        if (_filter.IsSafe(evt.ProcessName, evt.AccessMask, evt.ProcessId))
+            return;
+
+        // ハッシュ比較（ファイルが存在する場合のみ）
+        var originalHash = _store.GetOriginalHash(evt.ObjectName) ?? "";
+        var currentHash = ComputeCurrentHash(evt.ObjectName);
+        var tampered = !string.IsNullOrEmpty(currentHash)
+                       && !string.IsNullOrEmpty(originalHash)
+                       && currentHash != originalHash;
+
+        var eventType = tampered ? "Tampered" : GetAccessType(evt.AccessMask);
+
+        var alert = new MitsuoshieAlert
+        {
+            Timestamp = evt.Timestamp ?? DateTime.UtcNow,
+            HoneyFile = evt.ObjectName,
+            HoneyType = _store.GetHoneyType(evt.ObjectName) ?? HoneyTokenType.AwsCredential,
+            EventType = eventType,
+            Tampered = tampered,
+            OriginalHash = originalHash,
+            CurrentHash = currentHash,
+            AccessMask = evt.AccessMask,
+            ProcessId = evt.ProcessId,
+            ProcessName = Path.GetFileName(evt.ProcessName),
+            ProcessPath = evt.ProcessName,
+            User = evt.UserName,
+            Severity = AlertSeverity.Critical
+        };
+
+        AlertRaised?.Invoke(alert);
+    }
+
+    internal static string GetAccessType(string accessMask)
+    {
+        return accessMask switch
+        {
+            "0x1" => "ReadData",
+            "0x2" => "WriteData",
+            "0x4" => "AppendData",
+            "0x10000" => "Delete",
+            "0x80" => "ReadAttributes",
+            _ => $"Unknown({accessMask})"
+        };
+    }
+
+    private static string ComputeCurrentHash(string filePath)
+    {
+        if (!File.Exists(filePath))
+            return "";
+
+        var bytes = File.ReadAllBytes(filePath);
+        return Convert.ToHexStringLower(SHA256.HashData(bytes));
+    }
+}

--- a/tests/Mitsuoshie.Core.Tests/Monitoring/SecurityEventSubscriberTests.cs
+++ b/tests/Mitsuoshie.Core.Tests/Monitoring/SecurityEventSubscriberTests.cs
@@ -1,0 +1,164 @@
+namespace Mitsuoshie.Core.Tests.Monitoring;
+
+using Mitsuoshie.Core.Models;
+using Mitsuoshie.Core.Monitoring;
+
+public class SecurityEventSubscriberTests
+{
+    private readonly SettingsStore _store;
+    private readonly SafeProcessFilter _filter;
+
+    public SecurityEventSubscriberTests()
+    {
+        var tmpPath = Path.Combine(Path.GetTempPath(), "test_settings.json");
+        _store = new SettingsStore(tmpPath);
+        _store.AddToken(new DeployedToken(
+            @"C:\Users\test\.aws\credentials.bak",
+            HoneyTokenType.AwsCredential,
+            "abc123",
+            DateTime.UtcNow
+        ));
+
+        _filter = new SafeProcessFilter(
+            ["MsMpEng.exe", "SearchIndexer.exe"],
+            currentProcessId: 9999
+        );
+    }
+
+    [Fact]
+    public void ProcessEvent_HoneyFileAccess_RaisesAlert()
+    {
+        var subscriber = new SecurityEventSubscriber(_store, _filter);
+        MitsuoshieAlert? capturedAlert = null;
+        subscriber.AlertRaised += alert => capturedAlert = alert;
+
+        var evt = new SecurityEventData
+        {
+            ObjectName = @"C:\Users\test\.aws\credentials.bak",
+            AccessMask = "0x1",
+            ProcessId = 1234,
+            ProcessName = @"C:\temp\stealer.exe",
+            UserName = @"DESKTOP\test"
+        };
+
+        subscriber.ProcessEvent(evt);
+
+        Assert.NotNull(capturedAlert);
+        Assert.Equal(@"C:\Users\test\.aws\credentials.bak", capturedAlert.HoneyFile);
+        Assert.Equal(HoneyTokenType.AwsCredential, capturedAlert.HoneyType);
+        Assert.Equal("ReadData", capturedAlert.EventType);
+        Assert.Equal(1234, capturedAlert.ProcessId);
+        Assert.Equal("stealer.exe", capturedAlert.ProcessName);
+        Assert.Equal(AlertSeverity.Critical, capturedAlert.Severity);
+    }
+
+    [Fact]
+    public void ProcessEvent_NonHoneyFile_DoesNotRaiseAlert()
+    {
+        var subscriber = new SecurityEventSubscriber(_store, _filter);
+        MitsuoshieAlert? capturedAlert = null;
+        subscriber.AlertRaised += alert => capturedAlert = alert;
+
+        var evt = new SecurityEventData
+        {
+            ObjectName = @"C:\Users\test\Documents\normal.txt",
+            AccessMask = "0x1",
+            ProcessId = 1234,
+            ProcessName = @"C:\notepad.exe",
+            UserName = @"DESKTOP\test"
+        };
+
+        subscriber.ProcessEvent(evt);
+
+        Assert.Null(capturedAlert);
+    }
+
+    [Fact]
+    public void ProcessEvent_SafeProcess_DoesNotRaiseAlert()
+    {
+        var subscriber = new SecurityEventSubscriber(_store, _filter);
+        MitsuoshieAlert? capturedAlert = null;
+        subscriber.AlertRaised += alert => capturedAlert = alert;
+
+        var evt = new SecurityEventData
+        {
+            ObjectName = @"C:\Users\test\.aws\credentials.bak",
+            AccessMask = "0x1",
+            ProcessId = 1234,
+            ProcessName = @"C:\Windows\System32\MsMpEng.exe",
+            UserName = @"SYSTEM"
+        };
+
+        subscriber.ProcessEvent(evt);
+
+        Assert.Null(capturedAlert);
+    }
+
+    [Fact]
+    public void ProcessEvent_ReadAttributesOnly_DoesNotRaiseAlert()
+    {
+        var subscriber = new SecurityEventSubscriber(_store, _filter);
+        MitsuoshieAlert? capturedAlert = null;
+        subscriber.AlertRaised += alert => capturedAlert = alert;
+
+        var evt = new SecurityEventData
+        {
+            ObjectName = @"C:\Users\test\.aws\credentials.bak",
+            AccessMask = "0x80",
+            ProcessId = 1234,
+            ProcessName = @"C:\Windows\explorer.exe",
+            UserName = @"DESKTOP\test"
+        };
+
+        subscriber.ProcessEvent(evt);
+
+        Assert.Null(capturedAlert);
+    }
+
+    [Theory]
+    [InlineData("0x1", "ReadData")]
+    [InlineData("0x2", "WriteData")]
+    [InlineData("0x4", "AppendData")]
+    [InlineData("0x10000", "Delete")]
+    public void ProcessEvent_CorrectAccessType(string accessMask, string expectedEventType)
+    {
+        var subscriber = new SecurityEventSubscriber(_store, _filter);
+        MitsuoshieAlert? capturedAlert = null;
+        subscriber.AlertRaised += alert => capturedAlert = alert;
+
+        var evt = new SecurityEventData
+        {
+            ObjectName = @"C:\Users\test\.aws\credentials.bak",
+            AccessMask = accessMask,
+            ProcessId = 1234,
+            ProcessName = @"C:\temp\evil.exe",
+            UserName = @"DESKTOP\test"
+        };
+
+        subscriber.ProcessEvent(evt);
+
+        Assert.NotNull(capturedAlert);
+        Assert.Equal(expectedEventType, capturedAlert.EventType);
+    }
+
+    [Fact]
+    public void ProcessEvent_OwnProcess_DoesNotRaiseAlert()
+    {
+        var subscriber = new SecurityEventSubscriber(_store, _filter);
+        MitsuoshieAlert? capturedAlert = null;
+        subscriber.AlertRaised += alert => capturedAlert = alert;
+
+        var evt = new SecurityEventData
+        {
+            ObjectName = @"C:\Users\test\.aws\credentials.bak",
+            AccessMask = "0x1",
+            ProcessId = 9999, // 自プロセス
+            ProcessName = @"C:\Mitsuoshie\Mitsuoshie.exe",
+            UserName = @"DESKTOP\test"
+        };
+
+        subscriber.ProcessEvent(evt);
+
+        Assert.Null(capturedAlert);
+    }
+}


### PR DESCRIPTION
## Summary
- `SecurityEventData` — Event ID 4663 から抽出したデータの型定義
- `SecurityEventSubscriber` — イベント処理パイプライン
  - 罠ファイルパス照合 → SafeProcessFilter 除外 → ハッシュ比較 → アラート生成
  - ファイル不在時はハッシュ比較をスキップ（改ざんではなく削除として扱う）
- `AlertRaised` イベントで外部通知

Closes #14

## Test plan
- [x] 罠ファイルアクセスでアラート発火
- [x] 非罠ファイルアクセスは無視
- [x] 安全プロセスは除外
- [x] ReadAttributes のみは除外
- [x] アクセスマスク別の EventType 判定（4件）
- [x] 自プロセス除外
- [x] `dotnet test` 全70件 Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)