### PR TITLE
feat: IntegrityChecker 実装（定期ハッシュ比較）

### DIFF
--- a/src/Mitsuoshie.Core/Monitoring/IntegrityChecker.cs
+++ b/src/Mitsuoshie.Core/Monitoring/IntegrityChecker.cs
@@ -1,0 +1,85 @@
+using System.Security.Cryptography;
+using Mitsuoshie.Core.Models;
+
+namespace Mitsuoshie.Core.Monitoring;
+
+public class IntegrityChecker
+{
+    private readonly SettingsStore _store;
+
+    public IntegrityChecker(SettingsStore store)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+    }
+
+    /// <summary>
+    /// 全罠ファイルのハッシュを再計算し、改ざん・削除を検知する。
+    /// </summary>
+    public List<MitsuoshieAlert> CheckAll()
+    {
+        var alerts = new List<MitsuoshieAlert>();
+
+        foreach (var token in _store.Tokens)
+        {
+            var alert = CheckSingle(token);
+            if (alert is not null)
+                alerts.Add(alert);
+        }
+
+        return alerts;
+    }
+
+    private static MitsuoshieAlert? CheckSingle(DeployedToken token)
+    {
+        // ファイルが削除されている
+        if (!File.Exists(token.FilePath))
+        {
+            return new MitsuoshieAlert
+            {
+                Timestamp = DateTime.UtcNow,
+                HoneyFile = token.FilePath,
+                HoneyType = token.HoneyType,
+                EventType = "Deleted",
+                Tampered = false,
+                OriginalHash = token.OriginalHash,
+                CurrentHash = "",
+                AccessMask = "",
+                ProcessId = 0,
+                ProcessName = "unknown",
+                ProcessPath = "",
+                User = "",
+                Severity = AlertSeverity.Critical
+            };
+        }
+
+        // ハッシュ比較
+        var currentHash = ComputeHash(token.FilePath);
+        if (currentHash != token.OriginalHash)
+        {
+            return new MitsuoshieAlert
+            {
+                Timestamp = DateTime.UtcNow,
+                HoneyFile = token.FilePath,
+                HoneyType = token.HoneyType,
+                EventType = "Tampered",
+                Tampered = true,
+                OriginalHash = token.OriginalHash,
+                CurrentHash = currentHash,
+                AccessMask = "",
+                ProcessId = 0,
+                ProcessName = "unknown",
+                ProcessPath = "",
+                User = "",
+                Severity = AlertSeverity.Critical
+            };
+        }
+
+        return null; // 整合性OK
+    }
+
+    private static string ComputeHash(string filePath)
+    {
+        var bytes = File.ReadAllBytes(filePath);
+        return Convert.ToHexStringLower(SHA256.HashData(bytes));
+    }
+}

--- a/tests/Mitsuoshie.Core.Tests/Monitoring/IntegrityCheckerTests.cs
+++ b/tests/Mitsuoshie.Core.Tests/Monitoring/IntegrityCheckerTests.cs
@@ -1,0 +1,121 @@
+using System.Security.Cryptography;
+
+namespace Mitsuoshie.Core.Tests.Monitoring;
+
+using Mitsuoshie.Core.Models;
+using Mitsuoshie.Core.Monitoring;
+
+public class IntegrityCheckerTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly SettingsStore _store;
+
+    public IntegrityCheckerTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), "mitsuoshie_integrity_test_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_testDir);
+        _store = new SettingsStore(Path.Combine(_testDir, "settings.json"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+            Directory.Delete(_testDir, recursive: true);
+    }
+
+    [Fact]
+    public void CheckAll_NoChanges_ReturnsEmpty()
+    {
+        var filePath = CreateTestFile("test.txt", "original content");
+        var hash = ComputeHash(filePath);
+        _store.AddToken(new DeployedToken(filePath, HoneyTokenType.AwsCredential, hash, DateTime.UtcNow));
+
+        var checker = new IntegrityChecker(_store);
+        var alerts = checker.CheckAll();
+
+        Assert.Empty(alerts);
+    }
+
+    [Fact]
+    public void CheckAll_TamperedFile_ReturnsTamperedAlert()
+    {
+        var filePath = CreateTestFile("test.txt", "original content");
+        var hash = ComputeHash(filePath);
+        _store.AddToken(new DeployedToken(filePath, HoneyTokenType.SshKey, hash, DateTime.UtcNow));
+
+        // ファイルを改ざん
+        File.WriteAllText(filePath, "tampered content");
+
+        var checker = new IntegrityChecker(_store);
+        var alerts = checker.CheckAll();
+
+        Assert.Single(alerts);
+        Assert.Equal("Tampered", alerts[0].EventType);
+        Assert.True(alerts[0].Tampered);
+        Assert.Equal(HoneyTokenType.SshKey, alerts[0].HoneyType);
+        Assert.NotEqual(alerts[0].OriginalHash, alerts[0].CurrentHash);
+    }
+
+    [Fact]
+    public void CheckAll_DeletedFile_ReturnsDeletedAlert()
+    {
+        var filePath = Path.Combine(_testDir, "deleted.txt");
+        _store.AddToken(new DeployedToken(filePath, HoneyTokenType.EnvFile, "somehash", DateTime.UtcNow));
+
+        // ファイルは存在しない
+
+        var checker = new IntegrityChecker(_store);
+        var alerts = checker.CheckAll();
+
+        Assert.Single(alerts);
+        Assert.Equal("Deleted", alerts[0].EventType);
+        Assert.Equal(filePath, alerts[0].HoneyFile);
+    }
+
+    [Fact]
+    public void CheckAll_MultipleFiles_ChecksAll()
+    {
+        var file1 = CreateTestFile("file1.txt", "content1");
+        var file2 = CreateTestFile("file2.txt", "content2");
+        _store.AddToken(new DeployedToken(file1, HoneyTokenType.AwsCredential, ComputeHash(file1), DateTime.UtcNow));
+        _store.AddToken(new DeployedToken(file2, HoneyTokenType.SshKey, ComputeHash(file2), DateTime.UtcNow));
+
+        // file2 を改ざん
+        File.WriteAllText(file2, "tampered");
+
+        var checker = new IntegrityChecker(_store);
+        var alerts = checker.CheckAll();
+
+        Assert.Single(alerts);
+        Assert.Equal(file2, alerts[0].HoneyFile);
+    }
+
+    [Fact]
+    public void CheckAll_AllFilesIntact_ReturnsEmpty()
+    {
+        var file1 = CreateTestFile("a.txt", "aaa");
+        var file2 = CreateTestFile("b.txt", "bbb");
+        var file3 = CreateTestFile("c.txt", "ccc");
+        _store.AddToken(new DeployedToken(file1, HoneyTokenType.AwsCredential, ComputeHash(file1), DateTime.UtcNow));
+        _store.AddToken(new DeployedToken(file2, HoneyTokenType.SshKey, ComputeHash(file2), DateTime.UtcNow));
+        _store.AddToken(new DeployedToken(file3, HoneyTokenType.EnvFile, ComputeHash(file3), DateTime.UtcNow));
+
+        var checker = new IntegrityChecker(_store);
+        var alerts = checker.CheckAll();
+
+        Assert.Empty(alerts);
+    }
+
+    private string CreateTestFile(string name, string content)
+    {
+        var path = Path.Combine(_testDir, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static string ComputeHash(string filePath)
+    {
+        var bytes = File.ReadAllBytes(filePath);
+        return Convert.ToHexStringLower(SHA256.HashData(bytes));
+    }
+}


### PR DESCRIPTION
## Summary
- `IntegrityChecker` — 罠ファイルの整合性を定期チェック
- ファイル改ざん検知（SHA256 ハッシュ不一致 → Tampered アラート）
- ファイル削除検知（ファイル不在 → Deleted アラート）
- 全ファイル正常時は空リスト返却

Closes #15

## Test plan
- [x] 変更なしで空リスト
- [x] 改ざんファイルで Tampered アラート
- [x] 削除ファイルで Deleted アラート
- [x] 複数ファイルの一括チェック
- [x] 全ファイル正常で空リスト
- [x] `dotnet test` 全75件 Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)