### PR TITLE
feat: AlertGenerator 実装（アラート生成 + 重複抑制）

### DIFF
--- a/src/Mitsuoshie.Core/Detection/AlertGenerator.cs
+++ b/src/Mitsuoshie.Core/Detection/AlertGenerator.cs
@@ -1,0 +1,44 @@
+using System.Collections.Concurrent;
+using Mitsuoshie.Core.Models;
+
+namespace Mitsuoshie.Core.Detection;
+
+public class AlertGenerator
+{
+    private int _counter;
+    private readonly TimeSpan _suppressDuration;
+    private readonly ConcurrentDictionary<string, DateTime> _lastAlertTimes = new();
+
+    public AlertGenerator(TimeSpan? suppressDuration = null)
+    {
+        _suppressDuration = suppressDuration ?? TimeSpan.FromMinutes(5);
+    }
+
+    /// <summary>
+    /// 一意のアラートIDを生成する。MITSUOSHIE-YYYY-NNNN 形式。
+    /// </summary>
+    public string GenerateAlertId()
+    {
+        var num = Interlocked.Increment(ref _counter);
+        return $"MITSUOSHIE-{DateTime.UtcNow.Year}-{num:D4}";
+    }
+
+    /// <summary>
+    /// アラートを抑制すべきかどうかを判定する。
+    /// 同一プロセス + 同一ファイルの組み合わせで抑制期間内なら true。
+    /// 初回呼び出し時は記録して false を返す。
+    /// </summary>
+    public bool ShouldSuppress(MitsuoshieAlert alert)
+    {
+        var key = $"{alert.ProcessName}|{alert.ProcessId}|{alert.HoneyFile}";
+
+        if (_lastAlertTimes.TryGetValue(key, out var lastTime))
+        {
+            if (DateTime.UtcNow - lastTime < _suppressDuration)
+                return true;
+        }
+
+        _lastAlertTimes[key] = DateTime.UtcNow;
+        return false;
+    }
+}

--- a/tests/Mitsuoshie.Core.Tests/Detection/AlertGeneratorTests.cs
+++ b/tests/Mitsuoshie.Core.Tests/Detection/AlertGeneratorTests.cs
@@ -1,0 +1,105 @@
+namespace Mitsuoshie.Core.Tests.Detection;
+
+using Mitsuoshie.Core.Detection;
+using Mitsuoshie.Core.Models;
+
+public class AlertGeneratorTests
+{
+    [Fact]
+    public void GenerateAlertId_ReturnsExpectedFormat()
+    {
+        var generator = new AlertGenerator();
+        var id = generator.GenerateAlertId();
+
+        // MITSUOSHIE-2026-0001 形式
+        Assert.Matches(@"^MITSUOSHIE-\d{4}-\d{4}$", id);
+    }
+
+    [Fact]
+    public void GenerateAlertId_Increments()
+    {
+        var generator = new AlertGenerator();
+        var id1 = generator.GenerateAlertId();
+        var id2 = generator.GenerateAlertId();
+
+        Assert.NotEqual(id1, id2);
+        // 連番が増えているか
+        var num1 = int.Parse(id1.Split('-')[2]);
+        var num2 = int.Parse(id2.Split('-')[2]);
+        Assert.Equal(num1 + 1, num2);
+    }
+
+    [Fact]
+    public void ShouldSuppress_FirstAlert_ReturnsFalse()
+    {
+        var generator = new AlertGenerator(suppressDuration: TimeSpan.FromMinutes(5));
+        var alert = CreateAlert("malware.exe", 1234, @"C:\test\file.txt");
+
+        Assert.False(generator.ShouldSuppress(alert));
+    }
+
+    [Fact]
+    public void ShouldSuppress_SameProcessSameFile_WithinWindow_ReturnsTrue()
+    {
+        var generator = new AlertGenerator(suppressDuration: TimeSpan.FromMinutes(5));
+        var alert1 = CreateAlert("malware.exe", 1234, @"C:\test\file.txt");
+        var alert2 = CreateAlert("malware.exe", 1234, @"C:\test\file.txt");
+
+        generator.ShouldSuppress(alert1); // 記録
+        Assert.True(generator.ShouldSuppress(alert2)); // 抑制される
+    }
+
+    [Fact]
+    public void ShouldSuppress_DifferentProcess_ReturnsFalse()
+    {
+        var generator = new AlertGenerator(suppressDuration: TimeSpan.FromMinutes(5));
+        var alert1 = CreateAlert("malware.exe", 1234, @"C:\test\file.txt");
+        var alert2 = CreateAlert("stealer.exe", 5678, @"C:\test\file.txt");
+
+        generator.ShouldSuppress(alert1);
+        Assert.False(generator.ShouldSuppress(alert2));
+    }
+
+    [Fact]
+    public void ShouldSuppress_SameProcessDifferentFile_ReturnsFalse()
+    {
+        var generator = new AlertGenerator(suppressDuration: TimeSpan.FromMinutes(5));
+        var alert1 = CreateAlert("malware.exe", 1234, @"C:\test\file1.txt");
+        var alert2 = CreateAlert("malware.exe", 1234, @"C:\test\file2.txt");
+
+        generator.ShouldSuppress(alert1);
+        Assert.False(generator.ShouldSuppress(alert2));
+    }
+
+    [Fact]
+    public void ShouldSuppress_AfterWindowExpires_ReturnsFalse()
+    {
+        // 抑制期間を0秒に設定（即座に期限切れ）
+        var generator = new AlertGenerator(suppressDuration: TimeSpan.Zero);
+        var alert1 = CreateAlert("malware.exe", 1234, @"C:\test\file.txt");
+        var alert2 = CreateAlert("malware.exe", 1234, @"C:\test\file.txt");
+
+        generator.ShouldSuppress(alert1);
+        Assert.False(generator.ShouldSuppress(alert2)); // 期限切れなので抑制されない
+    }
+
+    private static MitsuoshieAlert CreateAlert(string processName, int processId, string honeyFile)
+    {
+        return new MitsuoshieAlert
+        {
+            Timestamp = DateTime.UtcNow,
+            HoneyFile = honeyFile,
+            HoneyType = HoneyTokenType.AwsCredential,
+            EventType = "ReadData",
+            Tampered = false,
+            OriginalHash = "hash",
+            CurrentHash = "hash",
+            AccessMask = "0x1",
+            ProcessId = processId,
+            ProcessName = processName,
+            ProcessPath = $@"C:\{processName}",
+            User = "user",
+            Severity = AlertSeverity.Critical
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- `AlertGenerator` — アラートID生成 + 重複抑制
- `GenerateAlertId()`: MITSUOSHIE-YYYY-NNNN 形式（Interlocked でスレッドセーフ）
- `ShouldSuppress()`: 同一プロセス+同一ファイルで5分間に1回に抑制

Closes #19

## Test plan
- [x] アラートIDが正しい形式
- [x] アラートIDが連番で増加
- [x] 初回アラートは抑制されない
- [x] 同一プロセス+同一ファイルは抑制される
- [x] 異なるプロセスは抑制されない
- [x] 異なるファイルは抑制されない
- [x] 期限切れ後は抑制されない
- [x] `dotnet test` 全82件 Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)