### PR TITLE
feat: WindowsEventLogger 実装（Windows Event Log 出力）

### DIFF
--- a/src/Mitsuoshie.Core/Logging/WindowsEventLogger.cs
+++ b/src/Mitsuoshie.Core/Logging/WindowsEventLogger.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics;
+using System.Runtime.Versioning;
+using System.Text;
+using Mitsuoshie.Core.Models;
+
+namespace Mitsuoshie.Core.Logging;
+
+[SupportedOSPlatform("windows")]
+public class WindowsEventLogger
+{
+    private const string SourceName = "Mitsuoshie";
+    private const string LogName = "Application";
+
+    /// <summary>
+    /// Windows Event Log にアラートを書き込む。
+    /// EventSource の登録には管理者権限が必要。
+    /// </summary>
+    public void WriteAlert(MitsuoshieAlert alert)
+    {
+        EnsureSourceExists();
+
+        var eventId = GetEventId(alert.EventType);
+        var message = FormatMessage(alert);
+        var entryType = EventLogEntryType.Warning;
+
+        EventLog.WriteEntry(SourceName, message, entryType, eventId);
+    }
+
+    /// <summary>
+    /// サービス開始イベントを書き込む。
+    /// </summary>
+    public void WriteServiceStart()
+    {
+        EnsureSourceExists();
+        EventLog.WriteEntry(SourceName, "Mitsuoshie service started.", EventLogEntryType.Information, 2000);
+    }
+
+    /// <summary>
+    /// サービス停止イベントを書き込む。
+    /// </summary>
+    public void WriteServiceStop()
+    {
+        EnsureSourceExists();
+        EventLog.WriteEntry(SourceName, "Mitsuoshie service stopped.", EventLogEntryType.Information, 2001);
+    }
+
+    /// <summary>
+    /// アラートの EventType からイベントIDを返す。
+    /// </summary>
+    public static int GetEventId(string eventType)
+    {
+        return eventType switch
+        {
+            "ReadData" => 1000,
+            "WriteData" => 1001,
+            "Delete" or "Deleted" => 1002,
+            "Tampered" => 1003,
+            _ => 1000
+        };
+    }
+
+    /// <summary>
+    /// アラートを Windows Event Log 用のメッセージ文字列にフォーマットする。
+    /// </summary>
+    public static string FormatMessage(MitsuoshieAlert alert)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Honeytoken access detected.");
+        sb.AppendLine($"File: {alert.HoneyFile}");
+        sb.AppendLine($"Type: {alert.HoneyType}");
+        sb.AppendLine($"Access: {alert.EventType} ({alert.AccessMask})");
+        sb.AppendLine($"Tampered: {alert.Tampered.ToString().ToLower()}");
+        sb.AppendLine($"Process: {alert.ProcessName} (PID: {alert.ProcessId})");
+        sb.AppendLine($"ProcessPath: {alert.ProcessPath}");
+        sb.AppendLine($"User: {alert.User}");
+        sb.AppendLine($"OriginalHash: SHA256={alert.OriginalHash}");
+        sb.AppendLine($"CurrentHash: SHA256={alert.CurrentHash}");
+        sb.AppendLine($"Timestamp: {alert.Timestamp:o}");
+        return sb.ToString();
+    }
+
+    private static void EnsureSourceExists()
+    {
+        if (!EventLog.SourceExists(SourceName))
+        {
+            EventLog.CreateEventSource(SourceName, LogName);
+        }
+    }
+}

--- a/src/Mitsuoshie.Core/Mitsuoshie.Core.csproj
+++ b/src/Mitsuoshie.Core/Mitsuoshie.Core.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="10.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Mitsuoshie.Core.Tests/Logging/WindowsEventLoggerTests.cs
+++ b/tests/Mitsuoshie.Core.Tests/Logging/WindowsEventLoggerTests.cs
@@ -1,0 +1,99 @@
+namespace Mitsuoshie.Core.Tests.Logging;
+
+using Mitsuoshie.Core.Logging;
+using Mitsuoshie.Core.Models;
+
+public class WindowsEventLoggerTests
+{
+    [Fact]
+    public void GetEventId_ReadData_Returns1000()
+    {
+        Assert.Equal(1000, WindowsEventLogger.GetEventId("ReadData"));
+    }
+
+    [Fact]
+    public void GetEventId_WriteData_Returns1001()
+    {
+        Assert.Equal(1001, WindowsEventLogger.GetEventId("WriteData"));
+    }
+
+    [Fact]
+    public void GetEventId_Delete_Returns1002()
+    {
+        Assert.Equal(1002, WindowsEventLogger.GetEventId("Delete"));
+    }
+
+    [Fact]
+    public void GetEventId_Tampered_Returns1003()
+    {
+        Assert.Equal(1003, WindowsEventLogger.GetEventId("Tampered"));
+    }
+
+    [Fact]
+    public void GetEventId_Deleted_Returns1002()
+    {
+        Assert.Equal(1002, WindowsEventLogger.GetEventId("Deleted"));
+    }
+
+    [Fact]
+    public void GetEventId_Unknown_Returns1000()
+    {
+        Assert.Equal(1000, WindowsEventLogger.GetEventId("Unknown"));
+    }
+
+    [Fact]
+    public void FormatMessage_ContainsAllFields()
+    {
+        var alert = new MitsuoshieAlert
+        {
+            Timestamp = new DateTime(2026, 3, 9, 12, 0, 0, DateTimeKind.Utc),
+            HoneyFile = @"C:\Users\test\.aws\credentials.bak",
+            HoneyType = HoneyTokenType.AwsCredential,
+            EventType = "ReadData",
+            Tampered = false,
+            OriginalHash = "abc123",
+            CurrentHash = "abc123",
+            AccessMask = "0x1",
+            ProcessId = 4832,
+            ProcessName = "stealer.exe",
+            ProcessPath = @"C:\temp\stealer.exe",
+            User = @"DESKTOP\test",
+            Severity = AlertSeverity.Critical
+        };
+
+        var message = WindowsEventLogger.FormatMessage(alert);
+
+        Assert.Contains("Honeytoken access detected", message);
+        Assert.Contains(@"C:\Users\test\.aws\credentials.bak", message);
+        Assert.Contains("ReadData", message);
+        Assert.Contains("stealer.exe", message);
+        Assert.Contains("4832", message);
+        Assert.Contains(@"DESKTOP\test", message);
+        Assert.Contains("abc123", message);
+    }
+
+    [Fact]
+    public void FormatMessage_TamperedAlert_ShowsTampered()
+    {
+        var alert = new MitsuoshieAlert
+        {
+            Timestamp = DateTime.UtcNow,
+            HoneyFile = "file",
+            HoneyType = HoneyTokenType.SshKey,
+            EventType = "Tampered",
+            Tampered = true,
+            OriginalHash = "original",
+            CurrentHash = "modified",
+            AccessMask = "",
+            ProcessId = 0,
+            ProcessName = "unknown",
+            ProcessPath = "",
+            User = "",
+            Severity = AlertSeverity.Critical
+        };
+
+        var message = WindowsEventLogger.FormatMessage(alert);
+
+        Assert.Contains("Tampered: true", message);
+    }
+}


### PR DESCRIPTION
## Summary
- `WindowsEventLogger` — アラートを Windows Application Event Log に出力
- EventID体系: 1000(読取), 1001(書込), 1002(削除), 1003(改ざん), 2000/2001(起動/停止)
- 設計書準拠のメッセージフォーマット
- `System.Diagnostics.EventLog` パッケージ追加

Closes #20

## Test plan
- [x] GetEventId が正しいマッピング（6件）
- [x] FormatMessage が全フィールドを含む
- [x] 改ざんアラートのフォーマット確認
- [x] `dotnet test` 全90件 Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)