### PR TITLE
feat: SysmonJsonLogger 実装（Sysmon互換 JSON ログ出力）

### DIFF
--- a/src/Mitsuoshie.Core/Logging/SysmonJsonLogger.cs
+++ b/src/Mitsuoshie.Core/Logging/SysmonJsonLogger.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Mitsuoshie.Core.Models;
+
+namespace Mitsuoshie.Core.Logging;
+
+public class SysmonJsonLogger
+{
+    private readonly string _logPath;
+    private readonly object _writeLock = new();
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = null, // PascalCase のまま
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public SysmonJsonLogger(string logPath)
+    {
+        _logPath = logPath ?? throw new ArgumentNullException(nameof(logPath));
+    }
+
+    /// <summary>
+    /// アラートを Sysmon 互換 JSON 形式でファイルに追記する（JSONL形式）。
+    /// </summary>
+    public void WriteAlert(MitsuoshieAlert alert, string alertId)
+    {
+        var entry = new SysmonEntry
+        {
+            EventId = 11,
+            EventType = "FileAccess",
+            RuleName = "Mitsuoshie:HoneytokenAccess",
+            UtcTime = alert.Timestamp.ToString("o"),
+            ProcessId = alert.ProcessId,
+            Image = alert.ProcessPath,
+            TargetFilename = alert.HoneyFile,
+            User = alert.User,
+            AccessMask = alert.AccessMask,
+            AccessType = alert.EventType,
+            Hashes = $"SHA256={alert.CurrentHash}",
+            MitsuoshieMetadata = new SysmonMetadata
+            {
+                HoneyType = alert.HoneyType.ToString(),
+                HoneyFile = alert.HoneyFile,
+                Severity = alert.Severity.ToString().ToLower(),
+                Tampered = alert.Tampered,
+                OriginalHash = $"SHA256={alert.OriginalHash}",
+                CurrentHash = $"SHA256={alert.CurrentHash}",
+                AlertId = alertId,
+                Description = $"{alert.HoneyType} honeytoken {alert.EventType.ToLower()} by {alert.ProcessName}"
+            }
+        };
+
+        var json = JsonSerializer.Serialize(entry, JsonOptions);
+
+        var dir = Path.GetDirectoryName(_logPath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        lock (_writeLock)
+        {
+            File.AppendAllText(_logPath, json + Environment.NewLine);
+        }
+    }
+
+    private record SysmonEntry
+    {
+        public int EventId { get; init; }
+        public string EventType { get; init; } = "";
+        public string RuleName { get; init; } = "";
+        public string UtcTime { get; init; } = "";
+        public int ProcessId { get; init; }
+        public string Image { get; init; } = "";
+        public string TargetFilename { get; init; } = "";
+        public string User { get; init; } = "";
+        public string AccessMask { get; init; } = "";
+        public string AccessType { get; init; } = "";
+        public string Hashes { get; init; } = "";
+        public SysmonMetadata MitsuoshieMetadata { get; init; } = new();
+    }
+
+    private record SysmonMetadata
+    {
+        public string HoneyType { get; init; } = "";
+        public string HoneyFile { get; init; } = "";
+        public string Severity { get; init; } = "";
+        public bool Tampered { get; init; }
+        public string OriginalHash { get; init; } = "";
+        public string CurrentHash { get; init; } = "";
+        public string AlertId { get; init; } = "";
+        public string Description { get; init; } = "";
+    }
+}

--- a/tests/Mitsuoshie.Core.Tests/Logging/SysmonJsonLoggerTests.cs
+++ b/tests/Mitsuoshie.Core.Tests/Logging/SysmonJsonLoggerTests.cs
@@ -1,0 +1,127 @@
+using System.Text.Json;
+
+namespace Mitsuoshie.Core.Tests.Logging;
+
+using Mitsuoshie.Core.Logging;
+using Mitsuoshie.Core.Models;
+
+public class SysmonJsonLoggerTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly string _logPath;
+
+    public SysmonJsonLoggerTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), "mitsuoshie_sysmon_test_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_testDir);
+        _logPath = Path.Combine(_testDir, "mitsuoshie_sysmon.jsonl");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+            Directory.Delete(_testDir, recursive: true);
+    }
+
+    [Fact]
+    public void WriteAlert_CreatesLogFile()
+    {
+        var logger = new SysmonJsonLogger(_logPath);
+        logger.WriteAlert(CreateAlert(), "MITSUOSHIE-2026-0001");
+
+        Assert.True(File.Exists(_logPath));
+    }
+
+    [Fact]
+    public void WriteAlert_AppendsJsonLine()
+    {
+        var logger = new SysmonJsonLogger(_logPath);
+        logger.WriteAlert(CreateAlert(), "MITSUOSHIE-2026-0001");
+        logger.WriteAlert(CreateAlert(), "MITSUOSHIE-2026-0002");
+
+        var lines = File.ReadAllLines(_logPath);
+        Assert.Equal(2, lines.Length);
+    }
+
+    [Fact]
+    public void WriteAlert_ProducesValidJson()
+    {
+        var logger = new SysmonJsonLogger(_logPath);
+        logger.WriteAlert(CreateAlert(), "MITSUOSHIE-2026-0001");
+
+        var line = File.ReadAllLines(_logPath)[0];
+        var doc = JsonDocument.Parse(line);
+        Assert.NotNull(doc);
+    }
+
+    [Fact]
+    public void WriteAlert_ContainsSysmonFields()
+    {
+        var logger = new SysmonJsonLogger(_logPath);
+        var alert = CreateAlert();
+        logger.WriteAlert(alert, "MITSUOSHIE-2026-0001");
+
+        var line = File.ReadAllLines(_logPath)[0];
+        var doc = JsonDocument.Parse(line);
+        var root = doc.RootElement;
+
+        Assert.Equal(11, root.GetProperty("EventId").GetInt32());
+        Assert.Equal("FileAccess", root.GetProperty("EventType").GetString());
+        Assert.Equal("Mitsuoshie:HoneytokenAccess", root.GetProperty("RuleName").GetString());
+        Assert.True(root.TryGetProperty("UtcTime", out _));
+        Assert.True(root.TryGetProperty("ProcessId", out _));
+        Assert.True(root.TryGetProperty("Image", out _));
+        Assert.True(root.TryGetProperty("TargetFilename", out _));
+        Assert.True(root.TryGetProperty("User", out _));
+        Assert.True(root.TryGetProperty("AccessMask", out _));
+        Assert.True(root.TryGetProperty("AccessType", out _));
+    }
+
+    [Fact]
+    public void WriteAlert_ContainsMitsuoshieMetadata()
+    {
+        var logger = new SysmonJsonLogger(_logPath);
+        logger.WriteAlert(CreateAlert(), "MITSUOSHIE-2026-0001");
+
+        var line = File.ReadAllLines(_logPath)[0];
+        var doc = JsonDocument.Parse(line);
+        var metadata = doc.RootElement.GetProperty("MitsuoshieMetadata");
+
+        Assert.Equal("AwsCredential", metadata.GetProperty("HoneyType").GetString());
+        Assert.Equal("critical", metadata.GetProperty("Severity").GetString());
+        Assert.Equal("MITSUOSHIE-2026-0001", metadata.GetProperty("AlertId").GetString());
+        Assert.True(metadata.TryGetProperty("Tampered", out _));
+        Assert.True(metadata.TryGetProperty("OriginalHash", out _));
+        Assert.True(metadata.TryGetProperty("CurrentHash", out _));
+    }
+
+    [Fact]
+    public void WriteAlert_CreatesDirectoryIfNeeded()
+    {
+        var deepPath = Path.Combine(_testDir, "sub", "dir", "log.jsonl");
+        var logger = new SysmonJsonLogger(deepPath);
+        logger.WriteAlert(CreateAlert(), "MITSUOSHIE-2026-0001");
+
+        Assert.True(File.Exists(deepPath));
+    }
+
+    private static MitsuoshieAlert CreateAlert()
+    {
+        return new MitsuoshieAlert
+        {
+            Timestamp = new DateTime(2026, 3, 9, 12, 0, 0, DateTimeKind.Utc),
+            HoneyFile = @"C:\Users\test\.aws\credentials.bak",
+            HoneyType = HoneyTokenType.AwsCredential,
+            EventType = "ReadData",
+            Tampered = false,
+            OriginalHash = "abc123",
+            CurrentHash = "abc123",
+            AccessMask = "0x1",
+            ProcessId = 4832,
+            ProcessName = "stealer.exe",
+            ProcessPath = @"C:\temp\stealer.exe",
+            User = @"DESKTOP\test",
+            Severity = AlertSeverity.Critical
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- `SysmonJsonLogger` — Sysmon互換JSON形式でアラートをファイルに出力
- JSONL形式（1行1JSON）で追記
- Sysmonフィールド + MitsuoshieMetadata の二層構造
- スレッドセーフな書き込み

Closes #21

## Test plan
- [x] ログファイルが作成される
- [x] 複数アラートが追記される（JSONL）
- [x] 有効なJSON出力
- [x] Sysmonフィールドが含まれる
- [x] MitsuoshieMetadata が含まれる
- [x] ディレクトリが自動作成される
- [x] `dotnet test` 全96件 Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)