### PR TITLE
feat: MitsuoshieService 実装（全コンポーネント統合サービス）

### DIFF
--- a/src/Mitsuoshie.Core/MitsuoshieService.cs
+++ b/src/Mitsuoshie.Core/MitsuoshieService.cs
@@ -1,0 +1,135 @@
+using Mitsuoshie.Core.Deployment;
+using Mitsuoshie.Core.Detection;
+using Mitsuoshie.Core.Logging;
+using Mitsuoshie.Core.Models;
+using Mitsuoshie.Core.Monitoring;
+
+namespace Mitsuoshie.Core;
+
+public class MitsuoshieService : IDisposable
+{
+    private readonly MitsuoshieServiceConfig _config;
+    private readonly HoneyDeployer _deployer;
+    private readonly AlertGenerator _alertGenerator;
+    private readonly SysmonJsonLogger _sysmonLogger;
+    private readonly WindowsEventLogger? _eventLogger;
+    private SettingsStore _store;
+    private SecurityEventSubscriber? _subscriber;
+    private SafeProcessFilter? _filter;
+    private Timer? _integrityTimer;
+
+    public event Action<MitsuoshieAlert>? AlertRaised;
+
+    public MitsuoshieService(MitsuoshieServiceConfig config)
+    {
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+        _deployer = new HoneyDeployer(config.UserProfileDir);
+        _alertGenerator = new AlertGenerator(TimeSpan.FromMinutes(config.SuppressDuplicateMinutes));
+        _sysmonLogger = new SysmonJsonLogger(config.SysmonLogPath);
+        _store = SettingsStore.Load(config.SettingsPath);
+
+        if (config.EnableWindowsEventLog)
+            _eventLogger = new WindowsEventLogger();
+    }
+
+    /// <summary>
+    /// 罠ファイルを配置し、設定を保存する。
+    /// </summary>
+    public List<DeployedToken> DeployTokens()
+    {
+        var results = _deployer.DeployAll();
+
+        foreach (var token in results)
+        {
+            _store.AddToken(token);
+        }
+
+        _store.Save();
+
+        // フィルタとサブスクライバを再構築
+        RebuildSubscriber();
+
+        return results;
+    }
+
+    /// <summary>
+    /// Security Event を処理する。外部から EventLogWatcher 経由で呼び出される。
+    /// </summary>
+    public void ProcessSecurityEvent(SecurityEventData evt)
+    {
+        _subscriber?.ProcessEvent(evt);
+    }
+
+    /// <summary>
+    /// 全罠ファイルの整合性チェックを実行する。
+    /// </summary>
+    public List<MitsuoshieAlert> CheckIntegrity()
+    {
+        var checker = new IntegrityChecker(_store);
+        var alerts = checker.CheckAll();
+
+        foreach (var alert in alerts)
+        {
+            HandleAlert(alert);
+        }
+
+        return alerts;
+    }
+
+    /// <summary>
+    /// 定期整合性チェックを開始する。
+    /// </summary>
+    public void StartIntegrityTimer()
+    {
+        var interval = TimeSpan.FromMinutes(_config.IntegrityCheckIntervalMinutes);
+        _integrityTimer = new Timer(_ => CheckIntegrity(), null, interval, interval);
+    }
+
+    /// <summary>
+    /// サービスを停止する。
+    /// </summary>
+    public void Stop()
+    {
+        _integrityTimer?.Dispose();
+        _integrityTimer = null;
+        _eventLogger?.WriteServiceStop();
+    }
+
+    public void Dispose()
+    {
+        Stop();
+    }
+
+    private void RebuildSubscriber()
+    {
+        _filter = new SafeProcessFilter(
+            _config.SafeProcessNames,
+            Environment.ProcessId
+        );
+
+        _subscriber = new SecurityEventSubscriber(_store, _filter);
+        _subscriber.AlertRaised += OnSubscriberAlert;
+    }
+
+    private void OnSubscriberAlert(MitsuoshieAlert alert)
+    {
+        if (_alertGenerator.ShouldSuppress(alert))
+            return;
+
+        HandleAlert(alert);
+    }
+
+    private void HandleAlert(MitsuoshieAlert alert)
+    {
+        var alertId = _alertGenerator.GenerateAlertId();
+
+        // Sysmon JSON ログ出力
+        _sysmonLogger.WriteAlert(alert, alertId);
+
+        // Windows Event Log 出力
+        _eventLogger?.WriteAlert(alert);
+
+        // 外部通知（UI等）
+        AlertRaised?.Invoke(alert);
+    }
+}

--- a/src/Mitsuoshie.Core/MitsuoshieServiceConfig.cs
+++ b/src/Mitsuoshie.Core/MitsuoshieServiceConfig.cs
@@ -1,0 +1,12 @@
+namespace Mitsuoshie.Core;
+
+public record MitsuoshieServiceConfig
+{
+    public required string UserProfileDir { get; init; }
+    public required string SettingsPath { get; init; }
+    public required string SysmonLogPath { get; init; }
+    public required IReadOnlyList<string> SafeProcessNames { get; init; }
+    public int IntegrityCheckIntervalMinutes { get; init; } = 30;
+    public int SuppressDuplicateMinutes { get; init; } = 5;
+    public bool EnableWindowsEventLog { get; init; } = true;
+}

--- a/tests/Mitsuoshie.Core.Tests/MitsuoshieServiceTests.cs
+++ b/tests/Mitsuoshie.Core.Tests/MitsuoshieServiceTests.cs
@@ -1,0 +1,202 @@
+using System.Security.Cryptography;
+
+namespace Mitsuoshie.Core.Tests;
+
+using Mitsuoshie.Core.Detection;
+using Mitsuoshie.Core.Logging;
+using Mitsuoshie.Core.Models;
+using Mitsuoshie.Core.Monitoring;
+
+public class MitsuoshieServiceTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly string _settingsPath;
+    private readonly string _logPath;
+
+    public MitsuoshieServiceTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), "mitsuoshie_svc_test_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_testDir);
+        _settingsPath = Path.Combine(_testDir, "settings.json");
+        _logPath = Path.Combine(_testDir, "sysmon.jsonl");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+            Directory.Delete(_testDir, recursive: true);
+    }
+
+    [Fact]
+    public void Constructor_CreatesInstance()
+    {
+        var config = CreateConfig();
+        var service = new MitsuoshieService(config);
+
+        Assert.NotNull(service);
+    }
+
+    [Fact]
+    public void DeployTokens_CreatesHoneyFiles()
+    {
+        var config = CreateConfig();
+        var service = new MitsuoshieService(config);
+
+        var results = service.DeployTokens();
+
+        Assert.NotEmpty(results);
+        foreach (var token in results)
+        {
+            Assert.True(File.Exists(token.FilePath));
+        }
+    }
+
+    [Fact]
+    public void DeployTokens_SavesSettings()
+    {
+        var config = CreateConfig();
+        var service = new MitsuoshieService(config);
+
+        service.DeployTokens();
+
+        Assert.True(File.Exists(_settingsPath));
+        var loaded = SettingsStore.Load(_settingsPath);
+        Assert.NotEmpty(loaded.Tokens);
+    }
+
+    [Fact]
+    public void DeployTokens_SkipsExistingFiles()
+    {
+        // 1つ先に配置
+        var awsPath = Path.Combine(_testDir, "profile", ".aws", "credentials.bak");
+        Directory.CreateDirectory(Path.GetDirectoryName(awsPath)!);
+        File.WriteAllText(awsPath, "existing");
+
+        var config = CreateConfig();
+        var service = new MitsuoshieService(config);
+        var results = service.DeployTokens();
+
+        Assert.DoesNotContain(results, t => t.HoneyType == HoneyTokenType.AwsCredential);
+    }
+
+    [Fact]
+    public void ProcessSecurityEvent_HoneyAccess_WritesJsonLog()
+    {
+        var config = CreateConfig();
+        var service = new MitsuoshieService(config);
+        service.DeployTokens();
+
+        // 罠ファイルのパスを取得
+        var store = SettingsStore.Load(_settingsPath);
+        var token = store.Tokens[0];
+
+        var evt = new SecurityEventData
+        {
+            ObjectName = token.FilePath,
+            AccessMask = "0x1",
+            ProcessId = 1234,
+            ProcessName = @"C:\temp\evil.exe",
+            UserName = @"DESKTOP\test"
+        };
+
+        service.ProcessSecurityEvent(evt);
+
+        Assert.True(File.Exists(_logPath));
+        var lines = File.ReadAllLines(_logPath);
+        Assert.Single(lines);
+    }
+
+    [Fact]
+    public void ProcessSecurityEvent_SafeProcess_NoLog()
+    {
+        var config = CreateConfig();
+        var service = new MitsuoshieService(config);
+        service.DeployTokens();
+
+        var store = SettingsStore.Load(_settingsPath);
+        var token = store.Tokens[0];
+
+        var evt = new SecurityEventData
+        {
+            ObjectName = token.FilePath,
+            AccessMask = "0x1",
+            ProcessId = 1234,
+            ProcessName = @"C:\Windows\System32\MsMpEng.exe",
+            UserName = "SYSTEM"
+        };
+
+        service.ProcessSecurityEvent(evt);
+
+        Assert.False(File.Exists(_logPath));
+    }
+
+    [Fact]
+    public void CheckIntegrity_NoChanges_NoAlerts()
+    {
+        var config = CreateConfig();
+        var service = new MitsuoshieService(config);
+        service.DeployTokens();
+
+        var alerts = service.CheckIntegrity();
+
+        Assert.Empty(alerts);
+    }
+
+    [Fact]
+    public void CheckIntegrity_TamperedFile_ReturnsAlert()
+    {
+        var config = CreateConfig();
+        var service = new MitsuoshieService(config);
+        service.DeployTokens();
+
+        // ファイルを改ざん
+        var store = SettingsStore.Load(_settingsPath);
+        File.WriteAllText(store.Tokens[0].FilePath, "tampered!");
+
+        var alerts = service.CheckIntegrity();
+
+        Assert.NotEmpty(alerts);
+        Assert.Contains(alerts, a => a.EventType == "Tampered");
+    }
+
+    [Fact]
+    public void AlertRaised_Event_IsFired()
+    {
+        var config = CreateConfig();
+        var service = new MitsuoshieService(config);
+        service.DeployTokens();
+
+        MitsuoshieAlert? capturedAlert = null;
+        service.AlertRaised += alert => capturedAlert = alert;
+
+        var store = SettingsStore.Load(_settingsPath);
+        var token = store.Tokens[0];
+
+        var evt = new SecurityEventData
+        {
+            ObjectName = token.FilePath,
+            AccessMask = "0x1",
+            ProcessId = 5555,
+            ProcessName = @"C:\temp\stealer.exe",
+            UserName = "user"
+        };
+
+        service.ProcessSecurityEvent(evt);
+
+        Assert.NotNull(capturedAlert);
+    }
+
+    private MitsuoshieServiceConfig CreateConfig()
+    {
+        return new MitsuoshieServiceConfig
+        {
+            UserProfileDir = Path.Combine(_testDir, "profile"),
+            SettingsPath = _settingsPath,
+            SysmonLogPath = _logPath,
+            SafeProcessNames = ["MsMpEng.exe", "SearchIndexer.exe"],
+            IntegrityCheckIntervalMinutes = 30,
+            SuppressDuplicateMinutes = 5,
+            EnableWindowsEventLog = false // テスト時は無効（管理者権限不要）
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- `MitsuoshieService` — 全コンポーネントを統合するオーケストレーター
- `MitsuoshieServiceConfig` — 設定レコード
- ライフサイクル: DeployTokens → ProcessSecurityEvent → CheckIntegrity → Stop
- 重複抑制 + SysmonJSON + WindowsEventLog + UI通知 を一括管理

Closes #25

## Test plan
- [x] インスタンス生成
- [x] 罠ファイル配置 + 存在確認
- [x] 設定ファイル保存
- [x] 既存ファイルのスキップ
- [x] イベント処理 → JSONログ出力
- [x] 安全プロセス → ログ出力なし
- [x] 整合性チェック（正常時/改ざん時）
- [x] AlertRaised イベント発火
- [x] `dotnet test` 全105件 Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)