### PR TITLE
feat: Mitsuoshie.App 実装（WinForms トレイアプリ）

### DIFF
--- a/Mitsuoshie.slnx
+++ b/Mitsuoshie.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/src/">
+    <Project Path="src/Mitsuoshie.App/Mitsuoshie.App.csproj" />
     <Project Path="src/Mitsuoshie.Core/Mitsuoshie.Core.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/src/Mitsuoshie.App/Mitsuoshie.App.csproj
+++ b/src/Mitsuoshie.App/Mitsuoshie.App.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mitsuoshie.Core\Mitsuoshie.Core.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/Mitsuoshie.App/MitsuoshieAppConfig.cs
+++ b/src/Mitsuoshie.App/MitsuoshieAppConfig.cs
@@ -1,0 +1,30 @@
+using Mitsuoshie.Core;
+
+namespace Mitsuoshie.App;
+
+public static class MitsuoshieAppConfig
+{
+    public static MitsuoshieServiceConfig CreateDefault()
+    {
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var mitsuoshieDir = Path.Combine(localAppData, "Mitsuoshie");
+
+        return new MitsuoshieServiceConfig
+        {
+            UserProfileDir = userProfile,
+            SettingsPath = Path.Combine(mitsuoshieDir, "settings.json"),
+            SysmonLogPath = Path.Combine(mitsuoshieDir, "logs", "mitsuoshie_sysmon.jsonl"),
+            SafeProcessNames = [
+                "MsMpEng.exe",
+                "SearchIndexer.exe",
+                "SearchProtocolHost.exe",
+                "TiWorker.exe",
+                "consent.exe"
+            ],
+            IntegrityCheckIntervalMinutes = 30,
+            SuppressDuplicateMinutes = 5,
+            EnableWindowsEventLog = true
+        };
+    }
+}

--- a/src/Mitsuoshie.App/Program.cs
+++ b/src/Mitsuoshie.App/Program.cs
@@ -1,0 +1,23 @@
+namespace Mitsuoshie.App;
+
+static class Program
+{
+    [STAThread]
+    static void Main()
+    {
+        // 多重起動防止
+        using var mutex = new Mutex(true, "Mitsuoshie_SingleInstance", out var isNew);
+        if (!isNew)
+        {
+            MessageBox.Show("Mitsuoshie は既に実行中です。", "Mitsuoshie",
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        ApplicationConfiguration.Initialize();
+
+        var config = MitsuoshieAppConfig.CreateDefault();
+        using var trayApp = new TrayApplicationContext(config);
+        Application.Run(trayApp);
+    }
+}

--- a/src/Mitsuoshie.App/StartupManager.cs
+++ b/src/Mitsuoshie.App/StartupManager.cs
@@ -1,0 +1,41 @@
+using System.Runtime.Versioning;
+using Microsoft.Win32;
+
+namespace Mitsuoshie.App;
+
+[SupportedOSPlatform("windows")]
+public static class StartupManager
+{
+    private const string RegistryKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
+    private const string AppName = "Mitsuoshie";
+
+    /// <summary>
+    /// スタートアップに登録する。
+    /// </summary>
+    public static void Register()
+    {
+        var exePath = Environment.ProcessPath;
+        if (string.IsNullOrEmpty(exePath)) return;
+
+        using var key = Registry.CurrentUser.OpenSubKey(RegistryKey, writable: true);
+        key?.SetValue(AppName, $"\"{exePath}\"");
+    }
+
+    /// <summary>
+    /// スタートアップから解除する。
+    /// </summary>
+    public static void Unregister()
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(RegistryKey, writable: true);
+        key?.DeleteValue(AppName, throwOnMissingValue: false);
+    }
+
+    /// <summary>
+    /// スタートアップに登録されているか確認する。
+    /// </summary>
+    public static bool IsRegistered()
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(RegistryKey);
+        return key?.GetValue(AppName) is not null;
+    }
+}

--- a/src/Mitsuoshie.App/TrayApplicationContext.cs
+++ b/src/Mitsuoshie.App/TrayApplicationContext.cs
@@ -1,0 +1,229 @@
+using System.Diagnostics.Eventing.Reader;
+using Mitsuoshie.Core;
+using Mitsuoshie.Core.Models;
+using Mitsuoshie.Core.Monitoring;
+
+namespace Mitsuoshie.App;
+
+public class TrayApplicationContext : ApplicationContext
+{
+    private readonly NotifyIcon _notifyIcon;
+    private readonly MitsuoshieService _service;
+    private EventLogWatcher? _eventWatcher;
+
+    public TrayApplicationContext(MitsuoshieServiceConfig config)
+    {
+        _service = new MitsuoshieService(config);
+        _service.AlertRaised += OnAlertRaised;
+
+        _notifyIcon = new NotifyIcon
+        {
+            Icon = CreateGreenIcon(),
+            Text = "Mitsuoshie — 監視中",
+            Visible = true,
+            ContextMenuStrip = CreateContextMenu()
+        };
+
+        Initialize();
+    }
+
+    private void Initialize()
+    {
+        try
+        {
+            // 罠ファイル配置
+            var deployed = _service.DeployTokens();
+
+            // 整合性チェック開始
+            _service.StartIntegrityTimer();
+
+            // Security Event Log 購読開始
+            StartEventLogWatcher();
+
+            UpdateStatus($"監視中（罠ファイル: {deployed.Count}個）");
+        }
+        catch (Exception ex)
+        {
+            ShowErrorNotification("初期化エラー", ex.Message);
+        }
+    }
+
+    private void StartEventLogWatcher()
+    {
+        try
+        {
+            var query = new EventLogQuery(
+                "Security",
+                PathType.LogName,
+                "*[System[EventID=4663]]"
+            );
+
+            _eventWatcher = new EventLogWatcher(query);
+            _eventWatcher.EventRecordWritten += OnSecurityEventReceived;
+            _eventWatcher.Enabled = true;
+        }
+        catch (Exception ex)
+        {
+            // Security Log の読み取りには権限が必要な場合がある
+            ShowErrorNotification("イベントログ購読エラー",
+                $"Security Event Log の購読に失敗しました: {ex.Message}");
+        }
+    }
+
+    private void OnSecurityEventReceived(object? sender, EventRecordWrittenEventArgs e)
+    {
+        if (e.EventRecord is null) return;
+
+        try
+        {
+            var record = e.EventRecord;
+            var evt = new SecurityEventData
+            {
+                ObjectName = record.Properties[6]?.Value?.ToString() ?? "",
+                AccessMask = record.Properties[9]?.Value?.ToString() ?? "",
+                ProcessId = Convert.ToInt32(record.Properties[8]?.Value ?? 0),
+                ProcessName = record.Properties[11]?.Value?.ToString() ?? "",
+                UserName = record.Properties[1]?.Value?.ToString() ?? "",
+                Timestamp = record.TimeCreated?.ToUniversalTime()
+            };
+
+            _service.ProcessSecurityEvent(evt);
+        }
+        catch
+        {
+            // イベント解析エラーは無視（壊れたイベントをスキップ）
+        }
+    }
+
+    private void OnAlertRaised(MitsuoshieAlert alert)
+    {
+        // UIスレッドで実行
+        _notifyIcon.Icon = CreateRedIcon();
+        _notifyIcon.Text = $"Mitsuoshie — 検知あり！ {alert.ProcessName}";
+
+        ShowAlertNotification(alert);
+
+        // 10秒後に緑に戻す
+        var timer = new System.Windows.Forms.Timer { Interval = 10000 };
+        timer.Tick += (_, _) =>
+        {
+            _notifyIcon.Icon = CreateGreenIcon();
+            _notifyIcon.Text = "Mitsuoshie — 監視中";
+            timer.Stop();
+            timer.Dispose();
+        };
+        timer.Start();
+    }
+
+    private void ShowAlertNotification(MitsuoshieAlert alert)
+    {
+        var title = "Mitsuoshie — ハニートークン検知";
+        var text = $"罠ファイルが{GetAccessDescription(alert.EventType)}されました\n"
+                 + $"ファイル: {Path.GetFileName(alert.HoneyFile)}\n"
+                 + $"プロセス: {alert.ProcessName} (PID: {alert.ProcessId})";
+
+        _notifyIcon.ShowBalloonTip(10000, title, text, ToolTipIcon.Warning);
+    }
+
+    private void ShowErrorNotification(string title, string message)
+    {
+        _notifyIcon.ShowBalloonTip(5000, $"Mitsuoshie — {title}", message, ToolTipIcon.Error);
+    }
+
+    private ContextMenuStrip CreateContextMenu()
+    {
+        var menu = new ContextMenuStrip();
+
+        var statusItem = new ToolStripMenuItem("ステータス: 初期化中...")
+        {
+            Name = "statusItem",
+            Enabled = false
+        };
+        menu.Items.Add(statusItem);
+        menu.Items.Add(new ToolStripSeparator());
+
+        var redeployItem = new ToolStripMenuItem("罠を再配置", null, (_, _) =>
+        {
+            var deployed = _service.DeployTokens();
+            UpdateStatus($"監視中（罠ファイル: {deployed.Count}個 再配置）");
+        });
+        menu.Items.Add(redeployItem);
+
+        var checkItem = new ToolStripMenuItem("整合性チェック", null, (_, _) =>
+        {
+            var alerts = _service.CheckIntegrity();
+            if (alerts.Count == 0)
+            {
+                _notifyIcon.ShowBalloonTip(3000, "Mitsuoshie", "全罠ファイルの整合性OK", ToolTipIcon.Info);
+            }
+            else
+            {
+                _notifyIcon.ShowBalloonTip(3000, "Mitsuoshie",
+                    $"異常検知: {alerts.Count}件", ToolTipIcon.Warning);
+            }
+        });
+        menu.Items.Add(checkItem);
+
+        menu.Items.Add(new ToolStripSeparator());
+
+        var exitItem = new ToolStripMenuItem("終了", null, (_, _) =>
+        {
+            _service.Stop();
+            _notifyIcon.Visible = false;
+            Application.Exit();
+        });
+        menu.Items.Add(exitItem);
+
+        return menu;
+    }
+
+    private void UpdateStatus(string status)
+    {
+        var statusItem = _notifyIcon.ContextMenuStrip?.Items.Find("statusItem", false).FirstOrDefault();
+        if (statusItem is not null)
+            statusItem.Text = $"ステータス: {status}";
+    }
+
+    private static string GetAccessDescription(string eventType)
+    {
+        return eventType switch
+        {
+            "ReadData" => "読み取り",
+            "WriteData" => "書き込み",
+            "Delete" or "Deleted" => "削除",
+            "Tampered" => "改ざん",
+            "AppendData" => "追記",
+            _ => "アクセス"
+        };
+    }
+
+    private static Icon CreateGreenIcon()
+    {
+        // 簡易的なプログラマティックアイコン生成（16x16 緑丸）
+        var bmp = new Bitmap(16, 16);
+        using var g = Graphics.FromImage(bmp);
+        g.Clear(Color.Transparent);
+        g.FillEllipse(Brushes.Green, 1, 1, 14, 14);
+        return Icon.FromHandle(bmp.GetHicon());
+    }
+
+    private static Icon CreateRedIcon()
+    {
+        var bmp = new Bitmap(16, 16);
+        using var g = Graphics.FromImage(bmp);
+        g.Clear(Color.Transparent);
+        g.FillEllipse(Brushes.Red, 1, 1, 14, 14);
+        return Icon.FromHandle(bmp.GetHicon());
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _eventWatcher?.Dispose();
+            _service.Dispose();
+            _notifyIcon.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}


### PR DESCRIPTION
## Summary
- `TrayApplicationContext` — タスクトレイ常駐アプリ
  - NotifyIcon（緑=正常, 赤=検知, 10秒後に自動復帰）
  - 右クリックメニュー: ステータス、罠再配置、整合性チェック、終了
  - バルーン通知（検知時にプロセス名・ファイル名を表示）
  - EventLogWatcher で Event ID 4663 を購読
- `MitsuoshieAppConfig` — デフォルト設定（%LOCALAPPDATA%\Mitsuoshie）
- `StartupManager` — レジストリによるスタートアップ登録/解除
- `Program` — Mutex による多重起動防止

Note: Toast通知は Microsoft.Toolkit.Uwp.Notifications が .NET 10 で互換性問題のため、
      NotifyIcon.ShowBalloonTip にフォールバック

Closes #26

## Test plan
- [x] `dotnet build` 成功
- [x] `dotnet test` 全105件 Green
- [x] コアロジックの統合テスト（MitsuoshieServiceTests）で動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)