### PR TITLE
feat: Inno Setup インストーラー + ビルドスクリプト + README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,9 @@ project.fragment.lock.json
 coverage/
 TestResults/
 
-# Publish
+# Publish & Installer output
 publish/
+dist/
 
 # IDE
 .idea/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,121 @@
+# Mitsuoshie（ミツオシエ）
+
+**Windows向けハニートークン検知ツール**
+
+「蜜の場所を教え、侵入者を罠に導く鳥 — Honeyguide」
+
+---
+
+## 概要
+
+Mitsuoshie は、Windows PC に罠ファイル（ハニートークン）を自動配置し、不正アクセスを検知するセキュリティツールです。
+
+- インストールするだけで罠ファイルを自動配置
+- ファイルにアクセスされたら即座に通知
+- 誤検知ほぼゼロ（正規アプリは罠ファイルにアクセスしない）
+- ブロックしない（検知と通知のみ）
+
+## 仕組み
+
+1. **罠を撒く** — AWS クレデンシャル、SSH 秘密鍵、パスワードファイルなどを模した罠ファイルを配置
+2. **監視する** — NTFS 監査 ACL（SACL）を設定し、Windows カーネルがアクセスを記録
+3. **通知する** — Event ID 4663 を購読し、罠ファイルへのアクセスを検知したら即座に通知
+
+## 配置される罠ファイル
+
+| 種別 | パス | 装うもの |
+|------|------|----------|
+| AWS Credential | `.aws\credentials.bak` | AWS クレデンシャルのバックアップ |
+| SSH Key | `.ssh\id_rsa.old` | SSH 秘密鍵の旧版 |
+| Env File | `.config\.env.production` | 本番環境の環境変数 |
+| Password File | `Documents\.secure\passwords.xlsx` | パスワード一覧 |
+| Crypto Wallet | `AppData\Roaming\Bitcoin\wallet.dat.bak` | Bitcoin ウォレット |
+| Browser Data | `Chrome\User Data\Login Data.bak` | ブラウザ保存パスワード |
+| Confidential | `Desktop\.confidential\重要_機密情報.docx` | 機密文書 |
+
+## インストール
+
+### インストーラー（推奨）
+
+1. [Releases](https://github.com/0x6d61/mitsuoshie/releases) から `MitsuoshieSetup-x.x.x.exe` をダウンロード
+2. 管理者として実行
+3. 「次へ」を数回クリックして完了
+
+### 手動ビルド
+
+```powershell
+# ビルド + テスト + publish
+pwsh build.ps1
+
+# テストのみ
+dotnet test
+
+# publish のみ
+dotnet publish src/Mitsuoshie.App -c Release -r win-x64 --self-contained -o publish/win-x64
+```
+
+## 要件
+
+- Windows 10 / 11
+- 管理者権限（初回 SACL 設定時のみ）
+
+## ログ出力
+
+### Windows Event Log
+
+- EventSource: `Mitsuoshie`
+- EventLog: `Application`
+- EventID: 1000（読取）, 1001（書込）, 1002（削除）, 1003（改ざん）
+
+### Sysmon 互換 JSON
+
+- 出力先: `%LOCALAPPDATA%\Mitsuoshie\logs\mitsuoshie_sysmon.jsonl`
+- JSONL 形式（1行1JSON）
+- SIEM / ログ分析ツールに直接投入可能
+
+## 技術スタック
+
+| コンポーネント | 技術 |
+|--------------|------|
+| 言語 | C# / .NET 10 |
+| ファイルアクセス検知 | NTFS SACL + Security Event Log (Event ID 4663) |
+| 整合性チェック | SHA256 ハッシュ比較（30分間隔） |
+| UI | WinForms NotifyIcon（タスクトレイ常駐） |
+| ログ | Windows Event Log + Sysmon 互換 JSON |
+| インストーラー | Inno Setup |
+
+## ライセンス
+
+MIT License
+
+---
+
+# Mitsuoshie
+
+**Honeytoken Detection Tool for Windows**
+
+"A honeyguide that leads intruders into traps"
+
+## Overview
+
+Mitsuoshie automatically deploys honeytoken files on Windows PCs and detects unauthorized access.
+
+- Install and forget — honeytokens are deployed automatically
+- Instant notification when a trap file is accessed
+- Near-zero false positives (legitimate apps never access trap files)
+- Detection only — no blocking
+
+## How It Works
+
+1. **Deploy** — Place fake credential files (AWS keys, SSH keys, passwords, etc.)
+2. **Monitor** — Set NTFS audit ACLs (SACL) so Windows kernel logs all access
+3. **Alert** — Subscribe to Event ID 4663 and notify on honeytoken access
+
+## Requirements
+
+- Windows 10 / 11
+- Administrator privileges (for initial SACL setup only)
+
+## License
+
+MIT License

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,55 @@
+# Mitsuoshie ビルドスクリプト
+# 使い方: pwsh build.ps1
+
+param(
+    [switch]$SkipTests,
+    [switch]$SkipInstaller
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== Mitsuoshie Build ===" -ForegroundColor Cyan
+
+# 1. テスト実行
+if (-not $SkipTests) {
+    Write-Host "`n[1/3] テスト実行中..." -ForegroundColor Yellow
+    dotnet test
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "テスト失敗！ビルドを中止します。" -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "テスト成功！" -ForegroundColor Green
+} else {
+    Write-Host "`n[1/3] テストスキップ" -ForegroundColor Gray
+}
+
+# 2. Publish（自己完結型）
+Write-Host "`n[2/3] Publish（win-x64, self-contained）..." -ForegroundColor Yellow
+$publishDir = Join-Path $PSScriptRoot "publish" "win-x64"
+dotnet publish src/Mitsuoshie.App -c Release -r win-x64 --self-contained -o $publishDir
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Publish 失敗！" -ForegroundColor Red
+    exit 1
+}
+Write-Host "Publish 成功: $publishDir" -ForegroundColor Green
+
+# 3. Inno Setup（インストーラー生成）
+if (-not $SkipInstaller) {
+    Write-Host "`n[3/3] インストーラー生成中..." -ForegroundColor Yellow
+    $iscc = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+    if (Test-Path $iscc) {
+        & $iscc installer\mitsuoshie.iss
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "インストーラー生成失敗！" -ForegroundColor Red
+            exit 1
+        }
+        Write-Host "インストーラー生成成功: dist/" -ForegroundColor Green
+    } else {
+        Write-Host "Inno Setup が見つかりません。インストーラー生成をスキップします。" -ForegroundColor Gray
+        Write-Host "インストール先: $iscc" -ForegroundColor Gray
+    }
+} else {
+    Write-Host "`n[3/3] インストーラースキップ" -ForegroundColor Gray
+}
+
+Write-Host "`n=== ビルド完了！ ===" -ForegroundColor Cyan

--- a/installer/mitsuoshie.iss
+++ b/installer/mitsuoshie.iss
@@ -1,0 +1,114 @@
+; Mitsuoshie Inno Setup Script
+; ハニートークン検知ツール インストーラー
+
+#define MyAppName "Mitsuoshie"
+#define MyAppVersion "1.0.0"
+#define MyAppPublisher "0x6d61"
+#define MyAppURL "https://github.com/0x6d61/mitsuoshie"
+#define MyAppExeName "Mitsuoshie.exe"
+
+[Setup]
+AppId={{8A3F5E2D-7B1C-4D6A-9E8F-0A2B3C4D5E6F}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+DefaultDirName={autopf}\{#MyAppName}
+DefaultGroupName={#MyAppName}
+AllowNoIcons=yes
+; 管理者権限を要求（SACL設定と監査ポリシーに必要）
+PrivilegesRequired=admin
+OutputDir=..\dist
+OutputBaseFilename=MitsuoshieSetup-{#MyAppVersion}
+Compression=lzma2/ultra64
+SolidCompression=yes
+WizardStyle=modern
+; 日本語優先、英語フォールバック
+ShowLanguageDialog=auto
+
+[Languages]
+Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "startup"; Description: "Windows 起動時に自動で開始する"; GroupDescription: "起動設定:"; Flags: checkedonce
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+; publish 出力ディレクトリからコピー
+Source: "..\publish\win-x64\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Run]
+; インストール後に監査ポリシーを有効化
+Filename: "auditpol"; Parameters: "/set /subcategory:""File System"" /success:enable"; \
+  Flags: runhidden waituntilterminated; StatusMsg: "ファイルシステム監査ポリシーを有効化中..."
+
+; インストール完了後にアプリを起動
+Filename: "{app}\{#MyAppExeName}"; Description: "{#MyAppName} を今すぐ起動する"; \
+  Flags: nowait postinstall skipifsilent
+
+[Registry]
+; スタートアップ登録（タスク選択時）
+Root: HKCU; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Run"; \
+  ValueType: string; ValueName: "{#MyAppName}"; ValueData: """{app}\{#MyAppExeName}"""; \
+  Flags: uninsdeletevalue; Tasks: startup
+
+[UninstallRun]
+; アンインストール時に監査ポリシーを復元（オプション）
+Filename: "auditpol"; Parameters: "/set /subcategory:""File System"" /success:disable"; \
+  Flags: runhidden waituntilterminated
+
+[UninstallDelete]
+; Mitsuoshie のローカルデータを削除
+Type: filesandordirs; Name: "{localappdata}\Mitsuoshie"
+
+[Code]
+// アンインストール時に罠ファイルを削除するか確認
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  UserProfile: String;
+  HoneyPaths: array of String;
+  I: Integer;
+  DeleteHoney: Boolean;
+begin
+  if CurUninstallStep = usUninstall then
+  begin
+    DeleteHoney := MsgBox(
+      '配置された罠ファイルも削除しますか？' + #13#10 +
+      '（残す場合は「いいえ」を選択してください）',
+      mbConfirmation, MB_YESNO) = IDYES;
+
+    if DeleteHoney then
+    begin
+      UserProfile := ExpandConstant('{userprofile}');
+
+      // 罠ファイルのパスリスト
+      SetArrayLength(HoneyPaths, 7);
+      HoneyPaths[0] := UserProfile + '\.aws\credentials.bak';
+      HoneyPaths[1] := UserProfile + '\.ssh\id_rsa.old';
+      HoneyPaths[2] := UserProfile + '\.config\.env.production';
+      HoneyPaths[3] := UserProfile + '\Documents\.secure\passwords.xlsx';
+      HoneyPaths[4] := UserProfile + '\AppData\Roaming\Bitcoin\wallet.dat.bak';
+      HoneyPaths[5] := UserProfile + '\AppData\Local\Google\Chrome\User Data\Login Data.bak';
+      HoneyPaths[6] := UserProfile + '\Desktop\.confidential\重要_機密情報.docx';
+
+      for I := 0 to GetArrayLength(HoneyPaths) - 1 do
+      begin
+        if FileExists(HoneyPaths[I]) then
+          DeleteFile(HoneyPaths[I]);
+      end;
+
+      // 隠しフォルダの削除
+      if DirExists(UserProfile + '\Documents\.secure') then
+        RemoveDir(UserProfile + '\Documents\.secure');
+      if DirExists(UserProfile + '\Desktop\.confidential') then
+        RemoveDir(UserProfile + '\Desktop\.confidential');
+    end;
+  end;
+end;

--- a/src/Mitsuoshie.App/Mitsuoshie.App.csproj
+++ b/src/Mitsuoshie.App/Mitsuoshie.App.csproj
@@ -10,6 +10,11 @@
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>Mitsuoshie</AssemblyName>
+    <Product>Mitsuoshie</Product>
+    <Description>Windows向けハニートークン検知ツール</Description>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- `installer/mitsuoshie.iss` — Inno Setup インストーラースクリプト
  - 管理者権限要求（auditpol で監査ポリシー有効化）
  - 日本語/英語言語サポート
  - スタートアップ登録（レジストリ、オプション）
  - アンインストーラー: 罠ファイル削除確認ダイアログ、監査ポリシー復元、ローカルデータ削除
- `build.ps1` — テスト → publish → インストーラー生成の一括ビルドスクリプト
- `README.md` — 日本語 + 英語の詳細説明
- `Mitsuoshie.App.csproj` — PublishSingleFile + SelfContained 有効化

Closes #29

## Test plan
- [x] `dotnet test` 全105件 Green
- [x] `dotnet build` 成功
- [x] Inno Setup スクリプトの構文確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)