### PR TITLE
feat: スタートアップ自動登録の有効化

### DIFF
--- a/Mitsuoshie.slnx
+++ b/Mitsuoshie.slnx
@@ -5,5 +5,6 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Mitsuoshie.Core.Tests/Mitsuoshie.Core.Tests.csproj" />
+    <Project Path="tests/Mitsuoshie.App.Tests/Mitsuoshie.App.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/Mitsuoshie.App/IStartupManager.cs
+++ b/src/Mitsuoshie.App/IStartupManager.cs
@@ -1,0 +1,11 @@
+namespace Mitsuoshie.App;
+
+/// <summary>
+/// Windows スタートアップ登録の抽象化。
+/// </summary>
+public interface IStartupManager
+{
+    void Register();
+    void Unregister();
+    bool IsRegistered();
+}

--- a/src/Mitsuoshie.App/StartupManager.cs
+++ b/src/Mitsuoshie.App/StartupManager.cs
@@ -5,7 +5,7 @@ using Microsoft.Win32;
 namespace Mitsuoshie.App;
 
 [SupportedOSPlatform("windows")]
-public static class StartupManager
+public class StartupManager : IStartupManager
 {
     private const string TaskName = "Mitsuoshie";
     private const string RegistryKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
@@ -15,7 +15,7 @@ public static class StartupManager
     /// 管理者権限がある場合は Task Scheduler（最高権限）で登録。
     /// ない場合はレジストリ Run キーにフォールバック。
     /// </summary>
-    public static void Register()
+    public void Register()
     {
         var exePath = Environment.ProcessPath;
         if (string.IsNullOrEmpty(exePath)) return;
@@ -33,7 +33,7 @@ public static class StartupManager
     /// <summary>
     /// スタートアップから解除する。
     /// </summary>
-    public static void Unregister()
+    public void Unregister()
     {
         UnregisterTaskScheduler();
         UnregisterRegistry();
@@ -42,7 +42,7 @@ public static class StartupManager
     /// <summary>
     /// スタートアップに登録されているか確認する。
     /// </summary>
-    public static bool IsRegistered()
+    public bool IsRegistered()
     {
         return IsTaskSchedulerRegistered() || IsRegistryRegistered();
     }

--- a/src/Mitsuoshie.App/StartupMenuHelper.cs
+++ b/src/Mitsuoshie.App/StartupMenuHelper.cs
@@ -5,7 +5,9 @@ namespace Mitsuoshie.App;
 /// </summary>
 public static class StartupMenuHelper
 {
-    public static ToolStripItem CreateStartupMenuItem(IStartupManager startupManager)
+    public static ToolStripItem CreateStartupMenuItem(
+        IStartupManager startupManager,
+        Action<string>? onError = null)
     {
         var registered = startupManager.IsRegistered();
         var item = new ToolStripMenuItem
@@ -16,18 +18,25 @@ public static class StartupMenuHelper
 
         item.Click += (_, _) =>
         {
-            if (startupManager.IsRegistered())
+            try
             {
-                startupManager.Unregister();
-            }
-            else
-            {
-                startupManager.Register();
-            }
+                if (startupManager.IsRegistered())
+                {
+                    startupManager.Unregister();
+                }
+                else
+                {
+                    startupManager.Register();
+                }
 
-            var nowRegistered = startupManager.IsRegistered();
-            item.Checked = nowRegistered;
-            item.Text = nowRegistered ? "スタートアップに登録済み" : "スタートアップに登録";
+                var nowRegistered = startupManager.IsRegistered();
+                item.Checked = nowRegistered;
+                item.Text = nowRegistered ? "スタートアップに登録済み" : "スタートアップに登録";
+            }
+            catch (Exception ex)
+            {
+                onError?.Invoke(ex.Message);
+            }
         };
 
         return item;

--- a/src/Mitsuoshie.App/StartupMenuHelper.cs
+++ b/src/Mitsuoshie.App/StartupMenuHelper.cs
@@ -1,0 +1,35 @@
+namespace Mitsuoshie.App;
+
+/// <summary>
+/// スタートアップ登録/解除のメニュー項目を生成するヘルパー。
+/// </summary>
+public static class StartupMenuHelper
+{
+    public static ToolStripItem CreateStartupMenuItem(IStartupManager startupManager)
+    {
+        var registered = startupManager.IsRegistered();
+        var item = new ToolStripMenuItem
+        {
+            Text = registered ? "スタートアップに登録済み" : "スタートアップに登録",
+            Checked = registered
+        };
+
+        item.Click += (_, _) =>
+        {
+            if (startupManager.IsRegistered())
+            {
+                startupManager.Unregister();
+            }
+            else
+            {
+                startupManager.Register();
+            }
+
+            var nowRegistered = startupManager.IsRegistered();
+            item.Checked = nowRegistered;
+            item.Text = nowRegistered ? "スタートアップに登録済み" : "スタートアップに登録";
+        };
+
+        return item;
+    }
+}

--- a/src/Mitsuoshie.App/TrayApplicationContext.cs
+++ b/src/Mitsuoshie.App/TrayApplicationContext.cs
@@ -43,14 +43,22 @@ public class TrayApplicationContext : ApplicationContext
 
     private void Initialize()
     {
+        // スタートアップに自動登録（失敗しても監視は続行）
         try
         {
-            // スタートアップに自動登録（未登録の場合のみ）
             if (!_startupManager.IsRegistered())
             {
                 _startupManager.Register();
             }
+        }
+        catch (Exception ex)
+        {
+            ShowErrorNotification("スタートアップ登録エラー",
+                $"自動起動の登録に失敗しました（監視は継続します）: {ex.Message}");
+        }
 
+        try
+        {
             // 罠ファイル配置 + SACL設定（管理者時）+ FileSystemWatcher開始
             var totalTokens = _service.DeployTokens();
 
@@ -219,7 +227,8 @@ public class TrayApplicationContext : ApplicationContext
         });
         menu.Items.Add(checkItem);
 
-        menu.Items.Add(StartupMenuHelper.CreateStartupMenuItem(_startupManager));
+        menu.Items.Add(StartupMenuHelper.CreateStartupMenuItem(_startupManager,
+            error => ShowErrorNotification("スタートアップ設定エラー", error)));
 
         menu.Items.Add(new ToolStripSeparator());
 

--- a/src/Mitsuoshie.App/TrayApplicationContext.cs
+++ b/src/Mitsuoshie.App/TrayApplicationContext.cs
@@ -11,12 +11,19 @@ public class TrayApplicationContext : ApplicationContext
 {
     private readonly NotifyIcon _notifyIcon;
     private readonly MitsuoshieService _service;
+    private readonly IStartupManager _startupManager;
     private readonly Icon _appIcon;
     private readonly Icon _alertIcon;
     private EventLogWatcher? _eventWatcher;
 
     public TrayApplicationContext(MitsuoshieServiceConfig config)
+        : this(config, new StartupManager())
     {
+    }
+
+    public TrayApplicationContext(MitsuoshieServiceConfig config, IStartupManager startupManager)
+    {
+        _startupManager = startupManager;
         _service = new MitsuoshieService(config);
         _service.AlertRaised += OnAlertRaised;
 
@@ -38,6 +45,12 @@ public class TrayApplicationContext : ApplicationContext
     {
         try
         {
+            // スタートアップに自動登録（未登録の場合のみ）
+            if (!_startupManager.IsRegistered())
+            {
+                _startupManager.Register();
+            }
+
             // 罠ファイル配置 + SACL設定（管理者時）+ FileSystemWatcher開始
             var totalTokens = _service.DeployTokens();
 
@@ -205,6 +218,8 @@ public class TrayApplicationContext : ApplicationContext
             }
         });
         menu.Items.Add(checkItem);
+
+        menu.Items.Add(StartupMenuHelper.CreateStartupMenuItem(_startupManager));
 
         menu.Items.Add(new ToolStripSeparator());
 

--- a/tests/Mitsuoshie.App.Tests/Mitsuoshie.App.Tests.csproj
+++ b/tests/Mitsuoshie.App.Tests/Mitsuoshie.App.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mitsuoshie.App\Mitsuoshie.App.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Mitsuoshie.App.Tests/StartupMenuTests.cs
+++ b/tests/Mitsuoshie.App.Tests/StartupMenuTests.cs
@@ -63,6 +63,21 @@ public class StartupMenuTests
         Assert.Equal("スタートアップに登録済み", item.Text);
     }
 
+    [Fact]
+    public void ClickMenuItem_WhenRegisterThrows_CallsOnError()
+    {
+        var fake = new ThrowingStartupManager();
+        string? capturedError = null;
+        var item = (ToolStripMenuItem)StartupMenuHelper.CreateStartupMenuItem(
+            fake, error => capturedError = error);
+
+        var exception = Record.Exception(() => item.PerformClick());
+
+        Assert.Null(exception);
+        Assert.False(item.Checked);
+        Assert.Contains("schtasks failed", capturedError);
+    }
+
     private class FakeStartupManager : IStartupManager
     {
         private bool _isRegistered;
@@ -84,5 +99,12 @@ public class StartupMenuTests
         }
 
         public bool IsRegistered() => _isRegistered;
+    }
+
+    private class ThrowingStartupManager : IStartupManager
+    {
+        public void Register() => throw new InvalidOperationException("schtasks failed");
+        public void Unregister() => throw new InvalidOperationException("schtasks failed");
+        public bool IsRegistered() => false;
     }
 }

--- a/tests/Mitsuoshie.App.Tests/StartupMenuTests.cs
+++ b/tests/Mitsuoshie.App.Tests/StartupMenuTests.cs
@@ -1,0 +1,88 @@
+using Mitsuoshie.App;
+
+namespace Mitsuoshie.App.Tests;
+
+public class StartupMenuTests
+{
+    [Fact]
+    public void CreateStartupMenuItem_WhenRegistered_ShowsChecked()
+    {
+        var fake = new FakeStartupManager(isRegistered: true);
+        var item = StartupMenuHelper.CreateStartupMenuItem(fake);
+
+        Assert.True(((ToolStripMenuItem)item).Checked);
+        Assert.Equal("スタートアップに登録済み", item.Text);
+    }
+
+    [Fact]
+    public void CreateStartupMenuItem_WhenNotRegistered_ShowsUnchecked()
+    {
+        var fake = new FakeStartupManager(isRegistered: false);
+        var item = StartupMenuHelper.CreateStartupMenuItem(fake);
+
+        Assert.False(((ToolStripMenuItem)item).Checked);
+        Assert.Equal("スタートアップに登録", item.Text);
+    }
+
+    [Fact]
+    public void ClickMenuItem_WhenNotRegistered_CallsRegister()
+    {
+        var fake = new FakeStartupManager(isRegistered: false);
+        var item = (ToolStripMenuItem)StartupMenuHelper.CreateStartupMenuItem(fake);
+
+        item.PerformClick();
+
+        Assert.True(fake.RegisterCalled);
+        Assert.False(fake.UnregisterCalled);
+    }
+
+    [Fact]
+    public void ClickMenuItem_WhenRegistered_CallsUnregister()
+    {
+        var fake = new FakeStartupManager(isRegistered: true);
+        var item = (ToolStripMenuItem)StartupMenuHelper.CreateStartupMenuItem(fake);
+
+        item.PerformClick();
+
+        Assert.True(fake.UnregisterCalled);
+        Assert.False(fake.RegisterCalled);
+    }
+
+    [Fact]
+    public void ClickMenuItem_TogglesCheckedState()
+    {
+        var fake = new FakeStartupManager(isRegistered: false);
+        var item = (ToolStripMenuItem)StartupMenuHelper.CreateStartupMenuItem(fake);
+
+        Assert.False(item.Checked);
+
+        item.PerformClick();
+
+        // After register, IsRegistered returns true → Checked should update
+        Assert.True(item.Checked);
+        Assert.Equal("スタートアップに登録済み", item.Text);
+    }
+
+    private class FakeStartupManager : IStartupManager
+    {
+        private bool _isRegistered;
+        public bool RegisterCalled { get; private set; }
+        public bool UnregisterCalled { get; private set; }
+
+        public FakeStartupManager(bool isRegistered) => _isRegistered = isRegistered;
+
+        public void Register()
+        {
+            RegisterCalled = true;
+            _isRegistered = true;
+        }
+
+        public void Unregister()
+        {
+            UnregisterCalled = true;
+            _isRegistered = false;
+        }
+
+        public bool IsRegistered() => _isRegistered;
+    }
+}


### PR DESCRIPTION
## Summary
- 起動時に `StartupManager.Register()` を呼び出し、Windows再起動後も自動で監視が開始されるようにした
- トレイメニューに「スタートアップに登録済み」トグルを追加（ユーザーがON/OFF可能）
- `IStartupManager` インターフェースを導入し、テスト可能な設計に変更

## Test plan
- [x] App.Tests 5件 全Green
- [x] 既存 Core.Tests 135件 全Green（リグレッションなし）
- [ ] 管理者権限での起動 → Task Scheduler にタスク登録されること
- [ ] 非管理者権限での起動 → Registry Run キーに登録されること
- [ ] トレイメニューからトグルで解除/再登録できること
- [ ] Windows再起動後に自動で起動すること

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)